### PR TITLE
Fix Android shadow quality modes

### DIFF
--- a/lib/BrickProfile.lua
+++ b/lib/BrickProfile.lua
@@ -64,11 +64,12 @@ function BrickProfile.actorShadowMapEnabled(level)
   return level == BrickProfile.DESKTOP_HIGH_LEVEL
 end
 
--- Active Brick rungs keep the cheap actor contact/blob fallback. The old
--- policy disabled every shadow at LOW and POTATO, which also disabled the
--- fallback decals and made NPCs appear to float. OFF remains shadow-free.
+-- HIGH, MEDIUM and LOW keep shadows; POTATO disables the shadow pass entirely
+-- to preserve the rung's minimum frame budget. OFF remains shadow-free.
+BrickProfile.POTATO_LEVEL = 4
 function BrickProfile.shadowsEnabled(level)
-  return (level or 0) > 0
+  level = level or 0
+  return level > 0 and level < BrickProfile.POTATO_LEVEL
 end
 
 -- The pipeline record and the rows hook captured the VOXEL ladder by
@@ -206,9 +207,9 @@ function BrickProfile.apply(V)
   ShadowMap.BRICK_HIGH_RES = 1536
 
   -- HIGH uses the full two-layer map on Brick/Android as well as desktop.
-  -- Lower Brick rungs turn the per-frame actor gate off in VoxelScene and
-  -- continue using the existing flat contact/blob decals, while the world
-  -- layer keeps the reduced Brick shadow policy.
+  -- MEDIUM and LOW turn the per-frame actor gate off in VoxelScene and
+  -- continue using the existing flat contact/blob decals. POTATO disables
+  -- the complete shadow pass, while HIGH keeps the two-layer map.
   ShadowMap.SPRITE_LAYER = true
 end
 

--- a/lib/SpriteBillboards.lua
+++ b/lib/SpriteBillboards.lua
@@ -92,14 +92,17 @@ local function buildShadowBlob()
     { -3, 0,  3, 0, 0, 1 }, { -6, 0,  2, 0, 0, 1 },
   }
   local indices = {}
+  -- LÖVE vertex maps are 1-based. The center vertex is 1 and the perimeter
+  -- vertices are 2..9; using zero-based indices can produce stretched
+  -- triangles on Android's GLES renderer.
   for i = 1, 7 do
-    indices[#indices + 1] = 0
-    indices[#indices + 1] = i
+    indices[#indices + 1] = 1
     indices[#indices + 1] = i + 1
+    indices[#indices + 1] = i + 2
   end
-  indices[#indices + 1] = 0
-  indices[#indices + 1] = 8
   indices[#indices + 1] = 1
+  indices[#indices + 1] = 9
+  indices[#indices + 1] = 2
   return Voxel3D.newMesh(verts, indices)
 end
 

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -1027,9 +1027,9 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor, eyes)
   -- reaches far north and barely south, which is right for every rung
   -- but a head free to face south.
   local shCx, shCy = FirstPerson.shadowCenter(cx, cy, vh)
-  -- Every active rung keeps shadows on. HIGH selects the real two-layer actor
-  -- map on all devices; MEDIUM and lower use the cheap contact/blob fallback
-  -- while the world map stays available for terrain and static geometry.
+  -- HIGH, MEDIUM and LOW keep shadows. POTATO disables the shadow pass for
+  -- its minimum frame budget; HIGH selects the real two-layer actor map on all
+  -- devices, while MEDIUM and LOW use the cheap contact/blob fallback.
   local shadowsOn = BrickProfile.shadowsEnabled(Voxel.level)
   if shadowsOn then
     castShadows(state, terrain, nbMesh, posed, shCx, shCy, vw, vh, atlasFor,


### PR DESCRIPTION
## Summary
- Disable all shadows in POTATO mode.
- Preserve the HIGH shadow-map path.
- Keep corrected contact-shadow mesh rendering for MEDIUM and LOW to prevent stretched shadows on Android.

## Validation
- Lua syntax validation passed for all changed Lua files.
- `git diff --check` passed.
- Changes were deployed and restarted on the connected Android device for testing.