### PR TITLE
Improve interoperability with UI and sprite mods

### DIFF
--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -355,6 +355,7 @@ end
 
 function OverworldBattle.textRects(battle)
   if not battle or battle.blankForAskName then return {} end
+  if battle.bottomUIVisible and not battle:bottomUIVisible() then return {} end
   local r = OverworldBattle.TEXT_RECT
   local out = { box = r.box }
   if battle.phase == "moveSelect" then
@@ -1386,12 +1387,12 @@ end
 
 -- Whether each HUD block is on screen this frame.
 --
--- READ-ONLY duplicates of drawHUDs' own two guards, because there is no seam
--- that reports "the enemy HUD is up". A panel under a HUD that is not there
--- would be a frosted slab floating in the arena, so it is worth mirroring;
--- the worst a future engine change can do is show an empty one for a frame,
--- never break a battle.
+-- READ-ONLY duplicates of drawHUDs' own guards. Honour the shared visibility
+-- seam first so hidden HUDs do not leave their frosted backings behind.
 function OverworldBattle.hudLive(battle, slide)
+  if battle.statusHUDVisible and not battle:statusHUDVisible() then
+    return false, false
+  end
   local enemy = battle.enemy and not battle.showEnemyTrainer
                 and not battle.enemySendingOut
                 and not battle:growInScale(battle.enemy) and slide == 0

--- a/main.lua
+++ b/main.lua
@@ -1256,13 +1256,12 @@ end)
 -- needs no battle code at all -- and every path that builds a battler goes
 -- through it, including a Transform mid-fight.
 --
--- next() first, so a sprite-replacing mod loaded before this one still gets
--- the last word on WHICH art is used; this only changes which SIDE is asked
--- for.
+-- Ask downstream art mods for their FRONT variant. This hook has to run before
+-- them: a complete front pic is what stands on the map, while many back pics
+-- end at the text-box edge baked into their artwork.
 mod.hooks:wrap("pokemon.sprite", function(next, path, ctx)
-  local out = next(path, ctx)
   if not (ctx and ctx.kind == "battle" and ctx.side == "back") then
-    return out
+    return next(path, ctx)
   end
   -- `battles` is stored in modOptions as the selected ladder value, not a
   -- boolean. The old truthy check enabled the alternate front-art path even
@@ -1270,10 +1269,15 @@ mod.hooks:wrap("pokemon.sprite", function(next, path, ctx)
   -- made the lower-left player battler use the wrong-facing asset. Only the
   -- explicit staged-map path needs front art; the flat/normal battle keeps the
   -- engine's canonical back sprite.
-  if not OverworldBattle.wantsFront() then return out end
+  if not OverworldBattle.wantsFront() then return next(path, ctx) end
   local def = ctx.data and ctx.data.pokemon and ctx.data.pokemon[ctx.species]
-  return (def and def.spriteFront) or out
-end)
+  local front = {}
+  for key, value in pairs(ctx) do front[key] = value end
+  front.side = "front"
+  local out = next((def and def.spriteFront) or path, front)
+  ctx.trueColor = front.trueColor
+  return out
+end, 1000)
 
 -- Every ending path emits this, including a battle skipped before it drew,
 -- so this is where the map's cast comes back.


### PR DESCRIPTION
## What

- Honor the engine's optional `bottomUIVisible()` and `statusHUDVisible()` seams before drawing PotatoVoxel's battle backings.
- Run staged front-sprite selection before downstream `pokemon.sprite` wrappers, passing a copied front-side context and propagating `trueColor` back to the caller.

## Why

The existing battle overlays can leave frosted panels behind after another mod hides the corresponding UI. The current sprite wrapper also asks downstream art mods for a back sprite and then replaces their result, so staged battles can bypass compatible sprite overrides.

Both changes remain optional: older engine objects without the visibility methods keep the current behavior, and there is no dependency on another mod.

## Testing

- LuaJIT syntax check for every Lua file
- `modkit lint` and `modkit validate`
- Android test with independent battle-UI visibility and sprite overrides enabled