### PR TITLE
Cover cold voxel mesh builds

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -5,3 +5,4 @@
 # private require against the archive (CONTRIBUTING-mods.md "What the PR
 # must contain", 2).
 tests/potato_voxel_test.lua
+tests/voxel_loading_test.lua

--- a/lib/VoxelLoading.lua
+++ b/lib/VoxelLoading.lua
@@ -1,0 +1,151 @@
+-- Opaque first-build cover for the asynchronous voxel world.
+-- Reuses Gen1Recomp's Town Map as a passive, ROM-backed illustration.
+
+local V = ...
+local Voxel = V.require("VoxelState")
+local Loading = {}
+
+local canvas, canvasW, canvasH = nil, 0, 0
+local townMapView, townMapFont, townMapGame = nil, nil, nil
+local townMapMapId, townMapFailed = nil, nil
+
+local clock = (love and love.timer and love.timer.getTime) or os.clock
+
+local function releaseObject(obj)
+  if obj and obj.release then pcall(obj.release, obj) end
+end
+
+local function releaseTownMap()
+  local bg = townMapView and townMapView.bg
+  if bg then
+    releaseObject(bg.img)
+    releaseObject(bg.cursor)
+    for _, quad in pairs(bg.quads or {}) do releaseObject(quad) end
+  end
+  releaseObject(townMapView and townMapView.nestIcon)
+  townMapView, townMapFont, townMapGame = nil, nil, nil
+  townMapMapId, townMapFailed = nil, nil
+end
+
+local function townMapForLoading()
+  local mapId = Voxel.loadingMap
+  if not mapId or townMapFailed == mapId then return nil end
+
+  local okG, Game = pcall(require, "src.core.Game")
+  if not (okG and Game and Game.data) then
+    townMapFailed = mapId
+    return nil
+  end
+  if not townMapView or townMapGame ~= Game then
+    releaseTownMap()
+    local okT, TownMap = pcall(require, "src.ui.TownMap")
+    local okF, Font = pcall(require, "src.render.Font")
+    local okV, view = false, nil
+    if okT then okV, view = pcall(TownMap.new, Game) end
+    if not (okV and view and view.mode == "grid" and view.bg
+            and okF and Font) then
+      townMapView = view
+      releaseTownMap()
+      townMapFailed = mapId
+      return nil
+    end
+    townMapView, townMapFont, townMapGame = view, Font, Game
+  end
+
+  local loc = townMapView.byMap and townMapView.byMap[mapId]
+  if not loc then
+    townMapFailed = mapId
+    return nil
+  end
+  townMapView.playerLoc = loc
+  for i, candidate in ipairs(townMapView.locs or {}) do
+    if candidate == loc then
+      townMapView.sel = i
+      break
+    end
+  end
+  townMapMapId = mapId
+  return townMapView, townMapFont
+end
+
+local function ensure(w, h)
+  if canvas and canvasW == w and canvasH == h then return true end
+  local ok, c = pcall(love.graphics.newCanvas, w, h)
+  if not (ok and c) then return false end
+  c:setFilter("nearest", "nearest")
+  releaseObject(canvas)
+  canvas, canvasW, canvasH = c, w, h
+  return true
+end
+
+local function drawTownMap(g, w, h, pending, elapsed)
+  local view, Font = townMapForLoading()
+  if not (view and Font) then return false end
+
+  local logicalW, logicalH = 160, 168
+  local scale = math.max(1, math.floor(
+    math.min((w - 8) / logicalW, (h - 8) / logicalH)))
+  local x = math.floor((w - logicalW * scale) * 0.5)
+  local y = math.floor((h - logicalH * scale) * 0.5)
+
+  g.push()
+  g.translate(x, y)
+  g.scale(scale, scale)
+  g.setLineWidth(1)
+  view.blink = math.floor(elapsed * 60) % 32
+  local ok = pcall(view.draw, view)
+  if ok then
+    Font.drawBox(0, 18, 20, 3)
+    g.setColor(0, 0, 0, 1)
+    local text = "BUILDING VOXELS"
+    if pending and pending > 1 and math.floor(elapsed / 2) % 2 == 1 then
+      text = tostring(pending) .. " AREAS LEFT"
+    end
+    Font.draw(text, math.floor((logicalW - Font.width(text)) * 0.5), 152)
+  end
+  g.pop()
+  g.setColor(1, 1, 1, 1)
+
+  if not ok then
+    local failed = townMapMapId or Voxel.loadingMap
+    releaseTownMap()
+    townMapFailed = failed
+    return false
+  end
+  return true
+end
+
+function Loading.draw(w, h, pending)
+  if not (love.graphics and love.graphics.newCanvas) then return nil end
+  if not ensure(w, h) then return nil end
+
+  local g = love.graphics
+  g.setCanvas(canvas)
+  g.setShader()
+  g.setBlendMode("alpha")
+  g.origin()
+  g.clear(0, 0, 0, 1)
+
+  local elapsed = clock() - (Voxel.loadingSince or clock())
+  if drawTownMap(g, w, h, pending, elapsed) then
+    g.setColor(1, 1, 1, 1)
+    g.setCanvas()
+    return canvas
+  end
+
+  g.setColor(1, 1, 1, 1)
+  local font = g.getFont()
+  local text = "BUILDING VOXELS"
+  g.print(text, math.floor((w - font:getWidth(text)) * 0.5),
+          math.floor(h * 0.5))
+  g.setCanvas()
+  return canvas
+end
+
+function Loading.invalidate()
+  releaseObject(canvas)
+  releaseTownMap()
+  canvas, canvasW, canvasH = nil, 0, 0
+end
+
+return Loading

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -498,7 +498,19 @@ function VoxelScene.prefetch(state)
       nbMesh[i], nbWater[i] = ChunkMesher.pair(nb.map, false)
     end
   end
-  Voxel.ready = terrain ~= nil
+  if Voxel.loading and Voxel.loadingMap ~= state.map.id then
+    Voxel.finishLoading()
+  end
+  local pending = ChunkMesher.pending()
+  if not terrain and pending > 0 then
+    Voxel.beginLoading(state.map.id)
+  elseif Voxel.loading and Voxel.loadingMap == state.map.id
+      and (terrain or pending == 0) then
+    -- A failed build reaches pending=0 too: release to vanilla rather than
+    -- trapping the player behind an infinite cover.
+    Voxel.finishLoading(state.map.id)
+  end
+  Voxel.ready = terrain ~= nil and not Voxel.loading
   return terrain, nbMesh, water, nbWater
 end
 

--- a/lib/VoxelState.lua
+++ b/lib/VoxelState.lua
@@ -131,6 +131,29 @@ Voxel.t = 1
 -- the whole frame for seconds).
 Voxel.ready = true
 
+-- A cold destination owns an opaque cover until its first terrain mesh lands,
+-- so the asynchronous build never leaks the vanilla 2D world.
+Voxel.loading = false
+Voxel.loadingMap = nil
+Voxel.loadingSince = 0
+
+local clock = (love and love.timer and love.timer.getTime) or os.clock
+
+function Voxel.beginLoading(mapId)
+  if Voxel.loading and Voxel.loadingMap == mapId then return end
+  Voxel.loading = true
+  Voxel.loadingMap = mapId
+  Voxel.loadingSince = clock()
+  Voxel.ready = false
+end
+
+function Voxel.finishLoading(mapId)
+  if mapId and Voxel.loadingMap ~= mapId then return end
+  Voxel.loading = false
+  Voxel.loadingMap = nil
+  Voxel.loadingSince = 0
+end
+
 Voxel.TWEEN_TIME = 0.25
 -- Camera distance as a multiple of the view height, and the matching field
 -- of view. Kept equal to Tilt.FOCAL so a given angle frames the world the
@@ -150,6 +173,7 @@ function Voxel.setLevel(level)
   if level < 0 then level = 0 end
   if level > Voxel.MAX_LEVEL then level = Voxel.MAX_LEVEL end
   local goal = goalFor(level)
+  if goal <= 0 then Voxel.finishLoading() end
   if goal ~= Voxel.goal or level ~= Voxel.level then
     Voxel.from = Voxel.angle
     Voxel.goal = goal
@@ -166,6 +190,7 @@ end
 function Voxel.reset()
   Voxel.level, Voxel.angle = 0, 0
   Voxel.from, Voxel.goal, Voxel.t = 0, 0, 1
+  Voxel.finishLoading()
 end
 
 function Voxel.levelLabel(level)

--- a/main.lua
+++ b/main.lua
@@ -108,6 +108,22 @@ local HordeHud = V.require("HordeHud")
 local DebugHud = V.require("DebugHud")
 local CachePrebuild = V.require("CachePrebuild")
 local HordeSfx = V.require("HordeSfx")
+local VoxelLoading = V.require("VoxelLoading")
+local publishedLoading
+
+local function publishLoading()
+  local loading = Voxel.loading == true
+  if publishedLoading == loading then return end
+  publishedLoading = loading
+  mod.events:emit("mod.potato_voxel.loading_changed", {
+    loading = loading,
+    mapId = Voxel.loadingMap,
+  })
+end
+
+mod.exports.isLoading = function()
+  return Voxel.loading == true, Voxel.loadingMap
+end
 
 -- The low-end runtime tuner (lib/BrickProfile.lua): the TrimUI Brick
 -- tuning this fork ships with, applied on every platform. Loaded on
@@ -258,14 +274,23 @@ mod.content.render_pipelines:register("voxel", {
     -- The cache prebuilder is deliberately independent of the active display
     -- mode: an Options-menu press must keep progressing while VOXEL is OFF.
     CachePrebuild.update()
-    if not Voxel.active() then return end
+    if not Voxel.active() then
+      publishLoading()
+      return
+    end
     local Game = require("src.core.Game")
     local ow = Game and Game.overworld
     if ow and ow.map and ow.camera then
       pcall(VoxelScene.prefetch, ow)
     end
-    ChunkMesher.pump(Game and Game.stack
-                     and Game.stack:top() ~= ow)
+    local covered = Game and Game.stack and Game.stack:top() ~= ow
+    ChunkMesher.pump(covered or Voxel.loading)
+    -- The covered slice may have completed the current terrain. Re-read now
+    -- so the loading canvas does not survive for one empty extra frame.
+    if Voxel.loading and ow and ow.map and ow.camera then
+      pcall(VoxelScene.prefetch, ow)
+    end
+    publishLoading()
   end,
 
   drawWorld = function(ctx)
@@ -289,6 +314,9 @@ mod.content.render_pipelines:register("voxel", {
     -- a magnified low-res image, while the FX closures keep drawing in
     -- world-pixel units.
     local sw, sh = sceneSize(ctx)
+    if Voxel.loading then
+      return VoxelLoading.draw(sw, sh, ChunkMesher.pending())
+    end
     -- With AA on, the whole pass runs into a canvas BIGGER than the window
     -- and is folded back down at the end (see AntiAlias).  Nothing between
     -- these two lines knows: every pass in the frame measures itself in the
@@ -344,11 +372,26 @@ mod.content.render_pipelines:register("voxel", {
     OverworldBattle.invalidate()
     AntiAlias.invalidate()
     Upscale.invalidate()
+    VoxelLoading.invalidate()
     ChunkMesher.invalidate()   -- no map id = every cached mesh
     ForestAtmos.invalidate()   -- shaft/particle meshes and shader sentinels
     VR.invalidate()            -- the mirror, and FBO ids of dead canvases
   end,
 })
+
+-- The loading cover hides gameplay, not time: the pipeline update above keeps
+-- pumping mesh jobs while scripts, encounters and invisible movement pause.
+do
+  local OverworldController = require("src.world.OverworldController")
+  if not OverworldController.potatoVoxelLoadingHook then
+    local inner = OverworldController.update
+    function OverworldController:update(dt)
+      if Voxel.loading then return end
+      return inner(self, dt)
+    end
+    OverworldController.potatoVoxelLoadingHook = true
+  end
+end
 
 -- The tilt-shift blur and its OPTIONS row are dropped on the Brick: the
 -- diorama is already ON its optimised framing there, and a full-screen

--- a/mod.card
+++ b/mod.card
@@ -32,6 +32,7 @@ return {
       "BACK SPRITES options row (OFF / ON, off by default), which keeps your own Pokemon on the battle menu in its classic slot",
       "VR options row (OFF / ON, off by default, desktop path only): PCVR through OpenXR on Windows -- the diorama as a head-tracked tabletop model. Requires the OpenXR loader, which PotatoVoxel no longer ships (restore assets/vr from the upstream mod to use it)",
       "a day/night clock that reaches the flat 2D overworld as well as the diorama",
+      "an opaque Town Map loading cover for cold asynchronous terrain builds, so the vanilla 2D world never flashes before the voxel mesh is ready",
       "an over-the-shoulder battle camera on a slow parallax orbit, with a depth-of-field pass that holds both mons sharp",
       "a sky behind the diorama at the 75-degree rung, outdoor maps only",
       "a hand-authored tile shape profile (data/voxel_heights.lua) a mod can extend",

--- a/tests/voxel_loading_test.lua
+++ b/tests/voxel_loading_test.lua
@@ -1,0 +1,114 @@
+local script = debug.getinfo(1, "S").source:gsub("^@", "")
+local root = script:match("^(.*)[/\\]tests[/\\][^/\\]+$") or "."
+local released, townMapBuilds, townMapDraws = 0, 0, 0
+local footer, clearColor
+
+-- Loading state is map-scoped and leaving voxel mode always releases it.
+do
+  local oldLove = love
+  love = { timer = { getTime = function() return 12.5 end } }
+  local voxel = assert(loadfile(root .. "/lib/VoxelState.lua"))()
+  voxel.beginLoading("PALLET_TOWN")
+  assert(voxel.loading and voxel.loadingMap == "PALLET_TOWN")
+  assert(voxel.loadingSince == 12.5)
+  voxel.finishLoading("ROUTE_1")
+  assert(voxel.loading, "another map released the cover")
+  voxel.setLevel(0)
+  assert(not voxel.loading, "voxel OFF kept the cover")
+  love = oldLove
+end
+
+local function resource()
+  return {
+    setFilter = function() end,
+    release = function() released = released + 1 end,
+  }
+end
+
+love = {
+  timer = { getTime = function() return 10 end },
+  graphics = {
+    newCanvas = function() return resource() end,
+    newFont = function()
+      return {
+        getWidth = function(_, text) return #text * 8 end,
+        release = function() released = released + 1 end,
+      }
+    end,
+    getFont = function()
+      return { getWidth = function(_, text) return #text * 8 end }
+    end,
+    setCanvas = function() end, setShader = function() end,
+    setBlendMode = function() end, setFont = function() end,
+    setColor = function() end, setLineWidth = function() end,
+    origin = function() end,
+    clear = function(...) clearColor = { ... } end,
+    rectangle = function() end, print = function() end,
+    push = function() end, pop = function() end,
+    translate = function() end, scale = function() end,
+  },
+}
+
+local location = { name = "PALLET TOWN", x = 4, y = 12 }
+local view
+local Game = { data = {}, save = {},
+               overworld = { map = { id = "PALLET_TOWN" } } }
+
+package.preload["src.core.Game"] = function() return Game end
+package.preload["src.ui.TownMap"] = function()
+  return {
+    new = function(game)
+      assert(game == Game)
+      townMapBuilds = townMapBuilds + 1
+      view = {
+        mode = "grid",
+        bg = {
+          img = resource(), cursor = resource(),
+          quads = { resource(), resource() },
+        },
+        byMap = { PALLET_TOWN = location },
+        locs = { location },
+        draw = function(self)
+          assert(self.playerLoc == location)
+          townMapDraws = townMapDraws + 1
+        end,
+      }
+      return view
+    end,
+  }
+end
+package.preload["src.render.Font"] = function()
+  return {
+    drawBox = function() end,
+    width = function(text) return #text * 8 end,
+    draw = function(text) footer = text end,
+  }
+end
+
+local Voxel = { loadingMap = "PALLET_TOWN", loadingSince = 1 }
+local V = {
+  require = function(name)
+    assert(name == "VoxelState")
+    return Voxel
+  end,
+}
+local Loading = assert(loadfile(root .. "/lib/VoxelLoading.lua"))(V)
+
+local first = Loading.draw(1920, 1080, 3)
+assert(first, "Town Map cover did not return its canvas")
+assert(townMapBuilds == 1 and townMapDraws == 1)
+assert(view.sel == 1 and view.playerLoc == location)
+assert(type(view.blink) == "number")
+assert(footer == "BUILDING VOXELS" or footer == "3 AREAS LEFT")
+assert(clearColor[1] == 0 and clearColor[2] == 0
+       and clearColor[3] == 0 and clearColor[4] == 1,
+       "loading letterbox is not opaque black")
+
+local second = Loading.draw(1920, 1080, 3)
+assert(second == first, "loading canvas was needlessly rebuilt")
+assert(townMapBuilds == 1 and townMapDraws == 2)
+
+Loading.invalidate()
+assert(released == 5, "loading resources were not all released")
+
+print("voxel loading tests: ok")


### PR DESCRIPTION
## What

- Track cold current-map terrain builds until the first drawable mesh is ready.
- Render an opaque, engine-backed Town Map cover while the asynchronous mesh queue continues to pump.
- Pause invisible overworld updates behind the cover, while failing open if a build ends without terrain or voxel mode is disabled.
- Expose the state through `mod.potato_voxel.loading_changed` and `mod.exports.isLoading` for optional consumers.

## Why

On a cold cache, the asynchronous renderer currently exposes the vanilla 2D world before the voxel terrain arrives. This is especially visible on slower Android handhelds. The cover only exists for a true cold build; cached maps and normal rendering are untouched.

## Testing

- Headless Lua test for map-scoped loading state, Town Map selection, opaque clearing, canvas reuse and resource cleanup
- LuaJIT syntax check for every Lua file
- `modkit lint` and `modkit validate`
- Cached startup and gameplay smoke test on an AYN Thor; the cold-cover path is covered headlessly