### PR TITLE
Hide empty enemy HUD panel during wild battle intro

### DIFF
--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -1396,6 +1396,7 @@ function OverworldBattle.hudLive(battle, slide)
   local enemy = battle.enemy and not battle.showEnemyTrainer
                 and not battle.enemySendingOut
                 and not battle:growInScale(battle.enemy) and slide == 0
+                and not battle.introBalls
                 and not battle.enemy.fainted
   local player = battle.player and not (battle.safari or battle.demo)
                  and not battle.showPlayerBack and slide == 0

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -15,6 +15,7 @@ if brick then
   local Water = exports.lib.require("Water")
   local ForestAtmos = exports.lib.require("ForestAtmos")
   local Structures = exports.lib.require("Structures")
+  local OverworldBattle = exports.lib.require("OverworldBattle")
   T.eq(#Voxel.ANGLES_DEG, 5, "VOXEL keeps OFF/HIGH/MEDIUM/LOW/POTATO")
   T.eq(Voxel.ANGLE_LABELS[1], "OFF", "VOXEL OFF rung is retained")
   T.eq(Voxel.ANGLE_LABELS[2], "HIGH", "VOXEL HIGH rung is retained")
@@ -36,6 +37,17 @@ if brick then
   T.eq(Structures.ROUND_RING, 12, "Brick keeps the full border ring")
   T.eq(Structures.HULL_BILLBOARDS, true, "Brick uses billboard hulls")
   T.eq(Structures.BILLBOARD_CROSS, true, "Brick crosses billboard hulls")
+  local intro = {
+    enemy = { fainted = false },
+    introBalls = true,
+    statusHUDVisible = function() return true end,
+    growInScale = function() return nil end,
+  }
+  T.eq(OverworldBattle.hudLive(intro, 0), false,
+       "wild intro does not show an empty enemy HUD panel")
+  intro.introBalls = nil
+  T.eq(OverworldBattle.hudLive(intro, 0), true,
+       "enemy HUD returns after the intro")
   local Prebuild = exports.lib.require("CachePrebuild")
   local jobs = Prebuild.enumerate({ B = { id="B", width=3, height=2, connections={} }, A = { id="A", width=4, height=5, connections={} } })
   T.eq(#jobs, 4, "prebuild enumerates body and full variants")


### PR DESCRIPTION
## Summary

`OverworldBattle.hudLive()` mirrors the host's `BattleState:drawHUDs()` visibility guards, but was missing the `introBalls` condition. During a wild battle's opening text, the host intentionally withholds the enemy HUD while PotatoVoxel still drew its empty frosted panel.

This adds the missing guard and a regression check confirming that the panel stays hidden during the intro and returns immediately afterward.

## Tests

- targeted `hudLive()` regression check
- `python tools/modkit.py lint mods/potato_voxel`
- `python tools/modkit.py validate mods/potato_voxel --base auto`