### PR TITLE
Add SHADOWS and SHADOW QUALITY settings (resolution 512-2048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.3.9] - 2026-08-11
+
+### Added
+
+- Added a SHADOWS row (ON / OFF). OFF is the flat-lit diorama: no shadow map
+  is drawn, the main pass is sent sunDark=0, and the contact blobs under the
+  characters go with it -- in free-roam and staged battles alike, so a device
+  that cannot carry the shadow pass can turn it off wholesale rather than
+  only dropping the expensive animated-actor layer.
+- Added a SHADOW QUALITY row (AUTO / 512 / 1024 / 2048). AUTO is the adaptive
+  ladder the pass always ran (the smallest size whose texel stays under a
+  target slice of a world pixel, capped at 2048); a fixed rung forces the
+  square shadow map's edge in texels whatever the view, so a player can trade
+  fill rate and RAM (a 2048 edge is a 16 MB depth pass, re-rasterised
+  whenever the shadow signature moves) for finer shadow edges.
+- Both rows are visible in every profile: they appear on the VOXEL SETTINGS
+  submenu and the mod manager's page whether the device runs the Brick
+  profile (which pins every other knob) or the full desktop mod, and stay on
+  the menu under the FULL preset.
+
+### Fixed
+
+- The shadow map canvas is now allocated at the fitted resolution rung
+  instead of staying pinned to the ladder's smallest size. The 1536 and 2048
+  rungs used to render into a 1024 (or 512 on the Brick) map whose fit, depth
+  bias and filter were computed for the finer rung; a fixed SHADOW QUALITY
+  rung now produces a map of exactly that size, and the Brick HIGH rung's
+  documented 1536 edge is real.
+
 ## [1.3.7] - 2026-08-11
 
 ### Added

--- a/lib/BattleScene.lua
+++ b/lib/BattleScene.lua
@@ -46,6 +46,7 @@ local VoxelState = V.require("VoxelState")
 local DayNight = V.require("DayNight")
 local BrickProfile = V.require("BrickProfile")
 local AntiAlias = V.require("AntiAlias")
+local ShadowSettings = V.require("ShadowSettings")
 local Upscale = V.require("Upscale")
 local PaletteFX = require("src.render.PaletteFX")
 local Map = require("src.world.Map")
@@ -558,9 +559,17 @@ function BattleScene.render(state, arena, textures, token)
   Voxel3D.camera = nil
   local actorShadows = BrickProfile.battleActorShadowMap(VoxelState.level)
   ShadowMap.setSpriteLayerActive(actorShadows)
-  castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh, atlasFor,
-              cards, token, host, neighbors, water, nbWater, groundY,
-              actorShadows)
+  -- The SHADOWS row is the last word over the arena too: OFF skips the sun
+  -- pass and the contact blobs alike (ShadowMap.off() drops both layers, so
+  -- the main pass sends sunDark=0 and the mons stand flat-lit).
+  local battleShadows = ShadowSettings.enabled()
+  if battleShadows then
+    castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh, atlasFor,
+                cards, token, host, neighbors, water, nbWater, groundY,
+                actorShadows)
+  else
+    ShadowMap.off()
+  end
 
   -- An opaque void either way. Outdoors the camera is low enough that the
   -- horizon is genuinely in frame, so it is sky; indoors it is the dark end
@@ -645,7 +654,7 @@ function BattleScene.render(state, arena, textures, token)
       end
     end
     end
-    if not discs and not actorShadows then
+    if battleShadows and not discs and not actorShadows then
       drawContactShadows(arena, groundY)
     end
     -- The mons, standing on their tiles. Depth-tested like everything else,

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -29,6 +29,7 @@ local V = ...
 
 local Mat4 = V.require("Mat4")
 local Voxel = V.require("VoxelState")
+local ShadowSettings = V.require("ShadowSettings")
 
 local ShadowMap = {}
 
@@ -76,7 +77,14 @@ ShadowMap.BRICK_HIGH_RES = nil
 
 -- Choose the square shadow-map edge for a fitted frustum. Kept separate from
 -- fit() so the profile's HIGH-size guarantee can be tested without a GPU.
+--
+-- The player's SHADOW QUALITY row wins first: a fixed rung (512/1024/2048)
+-- forces the map's edge whatever the view, and returns before the profile
+-- guarantees or the adaptive ladder can speak. AUTO (nil) falls through to
+-- the existing choice -- the Brick HIGH guarantee, then the ladder.
 function ShadowMap._resolutionFor(w, h, level)
+  local fixed = ShadowSettings.quality()
+  if fixed then return fixed end
   if level == 1 and ShadowMap.BRICK_HIGH_RES then
     return ShadowMap.BRICK_HIGH_RES
   end
@@ -572,8 +580,12 @@ function ShadowMap.begin(cx, cy, vw, vh, sprites)
   local sh = getShader()
   if not sh then return false end
   if not sprites then
-    -- fit first: it is what decides which resolution rung this view wants
+    -- fit first: it is what decides which resolution rung this view wants.
+    -- The canvas is then (re)made at that edge -- the rung's whole point is
+    -- how many texels the box is divided into, so a 1536 fit on a 1024
+    -- canvas would be a 1024 map wearing a 1536 fit's snap and bias.
     fit(cx, cy, vw, vh)
+    if getCanvas(ShadowMap.res) == nil then return false end
   end
   local c = sprites and spriteCanvas or canvas
   if not c or c == false then return false end

--- a/lib/ShadowSettings.lua
+++ b/lib/ShadowSettings.lua
@@ -1,0 +1,65 @@
+-- Voxel world mode: the player's knobs on the shadow map -- whether shadows
+-- are on at all, and how fine a shadow map to spend on them.
+--
+-- The shadow pass (ShadowMap) parameterises the voxel pass: it owns no pass
+-- of the frame itself, so the engine's render-pipeline registry would
+-- rightly reject it and the knobs are plain mod settings instead (see
+-- ModSetting). Both rows -- the one on the OPTIONS menu's VOXEL SETTINGS
+-- submenu and the one on the mod manager's page -- read and write the one
+-- stored value, so they cannot disagree.
+--
+--   SHADOWS        ON / OFF. OFF is the flat-lit diorama: no shadow map is
+--                  drawn, the main pass is sent sunDark=0, and the contact
+--                  blobs under the characters go with it -- nobody is
+--                  pasted on, there is simply no sun.
+--
+--   SHADOW QUALITY AUTO / 512 / 1024 / 2048. The edge of the square shadow
+--                  map, in texels. AUTO is the ladder the pass always ran
+--                  (ShadowMap.SIZES): the smallest size whose texel stays
+--                  under a target slice of a world pixel, capped at 2048. A
+--                  fixed rung forces the map's edge whatever the view, which
+--                  is the one knob a player can actually see -- bigger maps
+--                  resolve finer shadow edges and cost fill rate and RAM (a
+--                  2048 edge is a 16MB depth pass, re-rasterised whenever
+--                  the shadow signature moves), which is the whole of why
+--                  this is a row and not something that is simply on.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local ModSetting = V.require("ModSetting")
+
+local ShadowSettings = {}
+
+-- the keys under options.modOptions.DRAMATIC_SHAPE, shared by the row in
+-- OPTIONS and the mod manager's own settings page for this mod
+ShadowSettings.KEY = "shadows"
+ShadowSettings.LABEL = "SHADOWS"
+ShadowSettings.QUALITY_KEY = "shadowQuality"
+ShadowSettings.QUALITY_LABEL = "SHADOW QUALITY"
+
+-- ON is the default and the fallback: the mod ships with shadows on, and a
+-- fresh or unreadable save reads as ON rather than as a mode with nothing
+-- under anybody.
+ShadowSettings.enabledSetting = ModSetting.new(
+  ShadowSettings.KEY, ShadowSettings.LABEL, { true, false }, { "ON", "OFF" })
+
+-- AUTO (0) is the default and the fallback: the adaptive ladder is what the
+-- pass always did, so an unreadable save reads as the behaviour it shipped
+-- with rather than as a resolution somebody picked.
+ShadowSettings.qualitySetting = ModSetting.new(
+  ShadowSettings.QUALITY_KEY, ShadowSettings.QUALITY_LABEL,
+  { 0, 512, 1024, 2048 }, { "AUTO", "512", "1024", "2048" })
+
+function ShadowSettings.enabled()
+  return ShadowSettings.enabledSetting:get() and true or false
+end
+
+-- The fixed edge to force, in texels, or nil for the adaptive ladder.
+function ShadowSettings.quality()
+  local q = tonumber(ShadowSettings.qualitySetting:get()) or 0
+  if q <= 0 then return nil end
+  return q
+end
+
+return ShadowSettings

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -26,6 +26,7 @@ local Water = V.require("Water")
 local VoxelGrid = V.require("VoxelGrid")
 local DayNight = V.require("DayNight")
 local FirstPerson = V.require("FirstPerson")
+local ShadowSettings = V.require("ShadowSettings")
 local BattleBillboard = V.require("BattleBillboard")
 local Pokedex = V.require("Pokedex")
 local PaletteFX = require("src.render.PaletteFX")
@@ -1045,8 +1046,12 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor, eyes)
   local shCx, shCy = FirstPerson.shadowCenter(cx, cy, vh)
   -- Every active rung keeps shadows on. HIGH selects the real two-layer actor
   -- map on all devices; MEDIUM and lower use the cheap contact/blob fallback
-  -- while the world map stays available for terrain and static geometry.
+  -- while the world map stays available for terrain and static geometry. The
+  -- SHADOWS row is the last word over both -- OFF is the flat-lit diorama,
+  -- shadow map AND contact blobs together (ShadowMap.off() drops both layers
+  -- so the main pass sends sunDark=0).
   local shadowsOn = BrickProfile.shadowsEnabled(Voxel.level)
+                and ShadowSettings.enabled()
   if shadowsOn then
     castShadows(state, terrain, nbMesh, posed, shCx, shCy, vw, vh, atlasFor,
                 water, nbWater, battleCards, battleToken)

--- a/main.lua
+++ b/main.lua
@@ -92,6 +92,7 @@ local DayTint = V.require("DayTint")
 local Water = V.require("Water")
 local ForestAtmos = V.require("ForestAtmos")
 local AntiAlias = V.require("AntiAlias")
+local ShadowSettings = V.require("ShadowSettings")
 local Upscale = V.require("Upscale")
 local FirstPerson = V.require("FirstPerson")
 local FreeMove = V.require("FreeMove")
@@ -624,12 +625,32 @@ local SETTINGS = {
     .. "to make somebody ill in a headset. Turn it on if you have your sea "
     .. "legs and want the continuity.",
     when = function() return VR.enabled() end, full = true },
+  -- Marked `full` for the same reason as AA: not knobs on the look, what the
+  -- look COSTS, so FULL neither sets them nor takes the rows away -- the
+  -- player decides what their hardware can carry, from inside FULL like
+  -- anywhere else.
+  { ShadowSettings.enabledSetting,
+    "Cast real shadows across the diorama -- a shadow climbs a wall, drapes "
+    .. "over a roof and slides across a passing NPC. OFF is the flat-lit "
+    .. "model: no shadow map is drawn, no contact blobs sit under the "
+    .. "characters, and nothing reads as pasted on -- there just is no sun.",
+    full = true },
+  { ShadowSettings.qualitySetting,
+    "How fine a shadow map to spend on the pass, as the edge of the square "
+    .. "map in texels. AUTO is what the pass already does -- the smallest "
+    .. "size whose texel stays under a target slice of a world pixel, up to "
+    .. "2048. A fixed rung forces the map's edge whatever the view: bigger "
+    .. "maps resolve finer shadow edges and cost fill rate and RAM (2048 is "
+    .. "a 16MB depth pass), which is the whole of why this is a row.",
+    full = true },
 }
 
 -- On the Brick the settings schema is deliberately EMPTY: every knob is
 -- pinned by BrickProfile and there is nothing to configure, so the mod
--- manager's page is a card with no form. The VOXEL row still lives on the
--- OPTIONS menu, through the render-pipelines registry, as the quality
+-- manager's page is a card with no form. The two shadow rows are the one
+-- exception -- they stay live on the Brick (see voxelSettingsRows), so the
+-- Brick's page offers them and nothing else. The VOXEL row still lives on
+-- the OPTIONS menu, through the render-pipelines registry, as the quality
 -- ladder (OFF / HIGH / MEDIUM / LOW).
 local schema = {}
 if not BrickProfile.isBrick() then
@@ -639,6 +660,13 @@ if not BrickProfile.isBrick() then
     -- situational (a row hidden for now), this one is existential
     local vrOnly = entry[1] == VR.setting or entry[1] == VR.smoothTurn
     if not vrOnly or VR.supported() then
+      schema[#schema + 1] = entry[1]:schema(entry[2])
+    end
+  end
+else
+  for _, entry in ipairs(SETTINGS) do
+    if entry[1] == ShadowSettings.enabledSetting
+       or entry[1] == ShadowSettings.qualitySetting then
       schema[#schema + 1] = entry[1]:schema(entry[2])
     end
   end
@@ -938,6 +966,12 @@ local function voxelSettingsRows(game)
   for _, row in ipairs(Pipelines.rows(game)) do rows[#rows + 1] = row end
   if BrickProfile.isBrick() then
     rows[#rows + 1] = OverworldBattle.setting:row()
+    -- The shadow rows stay live on the Brick like 3D-BTL does: OFF is a
+    -- real frame-budget lever on a handheld, and SHADOW QUALITY a real
+    -- resolution one. The other SETTINGS knobs are pinned single-rung there
+    -- and would be dead switches, so they stay off this list.
+    rows[#rows + 1] = ShadowSettings.enabledSetting:row()
+    rows[#rows + 1] = ShadowSettings.qualitySetting:row()
   else
     local full = Voxel.isFull(Pipelines.level("voxel"))
     if full then

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -32,6 +32,41 @@ if brick then
   for level = 2, 4 do T.eq(brick.actorShadowMapEnabled(level), false, "lower modes use contact shadows") end
   for level = 1, 4 do T.eq(brick.shadowsEnabled(level), true, "active modes keep contact shadows") end
   T.eq(brick.shadowsEnabled(0), false, "OFF disables shadows")
+  local ShadowSettings = exports.lib.require("ShadowSettings")
+  T.eq(ShadowSettings.enabledSetting.values[1], true, "SHADOWS defaults to on")
+  T.eq(ShadowSettings.qualitySetting.values[1], 0, "SHADOW QUALITY defaults to AUTO")
+  T.check(ShadowSettings.enabled(), "SHADOWS reads ON under the Brick pin")
+  -- the SHADOW QUALITY row forces the map edge ahead of the profile's HIGH
+  -- guarantee, and AUTO (the Brick pin) lets the guarantee through
+  local qv, ql = ShadowSettings.qualitySetting.values,
+                 ShadowSettings.qualitySetting.labels
+  ShadowSettings.qualitySetting.values = { 0, 512, 1024, 2048 }
+  ShadowSettings.qualitySetting.labels = { "AUTO", "512", "1024", "2048" }
+  ShadowSettings.qualitySetting.index = nil
+  ShadowSettings.qualitySetting:setValue(2048)
+  T.eq(ShadowSettings.quality(), 2048, "quality 2048 forces the map edge")
+  T.eq(ShadowMap._resolutionFor(100, 100, 1), 2048,
+       "quality wins over the HIGH fixed 1536 map")
+  ShadowSettings.qualitySetting:setValue(512)
+  T.eq(ShadowMap._resolutionFor(100, 100, 1), 512,
+       "quality 512 forces a smaller map than the ladder would")
+  ShadowSettings.qualitySetting.values = qv
+  ShadowSettings.qualitySetting.labels = ql
+  ShadowSettings.qualitySetting.index = nil
+  T.eq(ShadowMap._resolutionFor(100, 100, 1), 1536,
+       "AUTO restores the HIGH fixed 1536 map")
+  -- the SHADOWS toggle gates the whole pass
+  local ev, el = ShadowSettings.enabledSetting.values,
+                 ShadowSettings.enabledSetting.labels
+  ShadowSettings.enabledSetting.values = { true, false }
+  ShadowSettings.enabledSetting.labels = { "ON", "OFF" }
+  ShadowSettings.enabledSetting.index = nil
+  ShadowSettings.enabledSetting:setValue(false)
+  T.check(not ShadowSettings.enabled(), "SHADOWS OFF disables the pass")
+  ShadowSettings.enabledSetting.values = ev
+  ShadowSettings.enabledSetting.labels = el
+  ShadowSettings.enabledSetting.index = nil
+  T.check(ShadowSettings.enabled(), "SHADOWS ON re-enables the pass")
   T.eq(Water.setting.values[1], "off", "WATER is pinned off")
   T.eq(ForestAtmos.setting.values[1], "off", "FOREST FX is pinned off")
   T.eq(Structures.ROUND_RING, 12, "Brick keeps the full border ring")

--- a/tests/shadow_cadence_probe.lua
+++ b/tests/shadow_cadence_probe.lua
@@ -43,10 +43,14 @@ local Mat4 = assert(loadfile(root .. "/lib/Mat4.lua"))()
 -- HIGH rung: level 1, a 0.9-rad camera pitch (the analysis scenario), and
 -- the FOCAL VoxelState ships with.
 local Voxel = { level = 1, angle = 0.9, FOCAL = 1.0 }
+-- the SHADOW QUALITY row is pinned AUTO by BrickProfile, so the probe's
+-- host answers AUTO (nil) and the ladder decides, exactly as on the Brick.
+local ShadowSettings = { quality = function() return nil end }
 local V = {
   require = function(name)
     if name == "Mat4" then return Mat4 end
     if name == "VoxelState" then return Voxel end
+    if name == "ShadowSettings" then return ShadowSettings end
     error("probe: unexpected require " .. tostring(name))
   end,
 }


### PR DESCRIPTION
Adds an ON/OFF SHADOWS row and an AUTO/512/1024/2048 SHADOW QUALITY row to the VOXEL SETTINGS submenu and the mod manager page, visible in every profile (Brick and desktop, under FULL and every rung).

- **SHADOWS** OFF disables the whole shadow pass in free-roam and staged battles: the sun map, the actor layer and the contact blobs, flat-lit via sunDark=0.
- **SHADOW QUALITY** forces the square shadow map's edge in texels (512/1024/2048); AUTO keeps the existing adaptive ladder.
- The map canvas is now allocated at the fitted resolution rung instead of staying pinned to the ladder's smallest size, so a 1536/2048 rung renders a map of that size and the Brick HIGH 1536 guarantee is real.

Tested headless: potato_voxel_test 66/66, cache_test 27/27, shadow_cadence_probe 624/624; modkit validate + lint clean.