### PR TITLE
Fix Windows map-cache build failing to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.4.1] - 2026-08-12
+
+### Fixed
+
+- The map-cache build now starts on Windows: the cache folder is created with
+  Windows-native commands (`if not exist ... mkdir ...` for each level instead
+  of the POSIX-only `mkdir -p`, which cmd.exe rejected by treating `-p` as a
+  folder name and choking on the `/dev/null` redirect). The build used to fail
+  the instant it began after a cache wipe, on every Windows release back to
+  1.3.3.
+
 ## [1.4.0] - 2026-08-12
 
 ### Added

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -216,6 +216,33 @@ MeshCache.identity = identity
 local dirTried = false
 local cacheDir = false          -- resolved once; false when unusable
 
+-- The shell commands that create the cache directory tree. Windows cmd has
+-- no `mkdir -p`: it cannot create missing parents and errors when the
+-- target already exists, so emit one guarded `if not exist ... mkdir ...`
+-- per component below the drive root (each level idempotent -- creating a
+-- missing level or skipping an existing one both exit cleanly). Everywhere
+-- else a single POSIX `mkdir -p` (stderr silenced) is enough. Exported so
+-- the headless suite can assert the exact commands without running cmd.exe.
+local function mkdirCommands(dir, sep)
+  if sep ~= "\\" then
+    local q = dir:gsub('"', '\\"')
+    return { 'mkdir -p "' .. q .. '" 2>/dev/null' }
+  end
+  local commands = {}
+  local acc = ""
+  for part in dir:gmatch("[^\\]+") do
+    if part ~= "" then
+      acc = acc == "" and part or (acc .. "\\" .. part)
+      if acc:match("^%a:\\") then
+        local q = acc:gsub('"', '\\"')
+        commands[#commands + 1] =
+          'if not exist "' .. q .. '" mkdir "' .. q .. '"'
+      end
+    end
+  end
+  return commands
+end
+
 function MeshCache.available()
   if not (ffi and love and love.graphics
           and love.data and love.data.newByteData) then
@@ -251,14 +278,10 @@ function MeshCache.dir()
   local d = base .. sep .. "mod-derived" .. sep .. "potato_voxel"
             .. sep .. "meshes"
   -- io.* cannot create missing parents; mkdir the tree like the engine's
-  -- portable filesystem does
-  local q = d:gsub('"', '\\"')
-  local ok = os.execute('mkdir -p "' .. q .. '" 2>/dev/null')
-  if not (ok == true or ok == 0) then
-    -- Windows cmd has no mkdir -p; its plain mkdir creates the whole
-    -- tree, so try that before giving up (failure stays a silent no-op).
-    local ok2 = os.execute('mkdir "' .. q .. '" 2>nul')
-    if not (ok2 == true or ok2 == 0) then return nil end
+  -- portable filesystem does. Failure stays a silent no-op (nil above).
+  for _, command in ipairs(mkdirCommands(d, sep)) do
+    local ok = os.execute(command)
+    if not (ok == true or ok == 0) then return nil end
   end
   cacheDir = d
   return d
@@ -1031,6 +1054,8 @@ end
 -- serialized bytes; decodeMesh reads them back.
 MeshCache.encodeMesh = encodeMesh
 MeshCache.decodeMesh = decodeMesh
+-- mkdir command builder for MeshCache.dir, exported for tests
+MeshCache.mkdirCommands = mkdirCommands
 -- indexed terrain/water payloads (brick.11+)
 MeshCache.encodeIndexed = encodeIndexed
 MeshCache.decodeIndexed = decodeIndexed

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -57,6 +57,24 @@ MeshCache.configure({ maps = maps, tilesets = {} })
 T.check(firstIdentity ~= MeshCache.identity(),
         "map data changes the cache identity")
 
+local posixMkdir = MeshCache.mkdirCommands(
+  "/home/user/.local/share/love/game/mod-derived/potato_voxel/meshes", "/")
+T.eq(type(posixMkdir), "table", "mkdir commands come back as a list")
+T.eq(#posixMkdir, 1, "POSIX tree creation is a single command")
+T.eq(posixMkdir[1],
+     'mkdir -p "/home/user/.local/share/love/game/mod-derived/potato_voxel/meshes" 2>/dev/null',
+     "POSIX uses mkdir -p with silenced stderr")
+local winMkdir = MeshCache.mkdirCommands(
+  "C:\\LOVE\\game\\mod-derived\\potato_voxel\\meshes", "\\")
+T.eq(#winMkdir, 5, "Windows creates each component below the drive root")
+T.eq(winMkdir[1], 'if not exist "C:\\LOVE" mkdir "C:\\LOVE"',
+     "Windows guards the drive-level folder")
+T.eq(winMkdir[2], 'if not exist "C:\\LOVE\\game" mkdir "C:\\LOVE\\game"',
+     "Windows guards each intermediate folder")
+T.eq(winMkdir[5],
+     'if not exist "C:\\LOVE\\game\\mod-derived\\potato_voxel\\meshes" mkdir "C:\\LOVE\\game\\mod-derived\\potato_voxel\\meshes"',
+     "Windows deepest component is the cache dir itself")
+
 local record = MeshCache.jobRecord({
   id = "A", tileset = { image = "tileset.png", trueColor = false },
   renderer = { gbcAtlas = false },


### PR DESCRIPTION
Fixes #17.

## Root cause

`MeshCache.dir()` created the cache tree with `os.execute('mkdir -p "<dir>" 2>/dev/null')`, which is POSIX-only. Under Windows `cmd.exe`:

- `2>/dev/null` is a redirect to a path (`\dev\null`) that doesn't exist, so the whole command fails before `mkdir` runs — and `-p` is not a cmd switch.
- The `mkdir "<dir>" 2>nul` fallback then fails twice over: cmd's `mkdir` cannot create missing parents **and** returns exit 1 when the directory already exists.

So `dir()` returned `nil` → `MeshCache.available()` was false → the cache build never started, on every Windows release back to 1.3.3.

## Fix

Branch on the already-computed `package.config` separator (same pattern `listFiles()` uses):

- **POSIX:** one `mkdir -p "<dir>" 2>/dev/null` — unchanged behavior.
- **Windows:** one guarded `if not exist "<component>" mkdir "<component>"` per path component below the drive root. A fresh install now creates the missing `mod-derived\potato_voxel\meshes` levels, and an existing level is skipped instead of erroring.

The command builder is exported as `MeshCache.mkdirCommands(dir, sep)` so the headless suite asserts both platform branches without needing real `cmd.exe` in CI.

## Validation

- `tests/potato_voxel_cache_test.lua` — 34/34 checks (8 new assertions for both platforms)
- `tests/potato_voxel_test.lua` — 90/90 checks
- `modkit lint` and `modkit validate` — ok