### PR TITLE
1.4.2: fix cache rebuild prompts, resume interrupted builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.4.2] - 2026-08-12
+
+### Fixed
+
+- The map cache no longer rebuilds on every app launch (Android). The cache
+  identity now snapshots once at build start (`begin()`), so every payload
+  file and the manifest share a single build-session identity even if a live
+  identity component (like the VOID FILL setting) changes mid-build -- the
+  manifest can no longer be stamped with a different identity than the files
+  it describes. A relaunch with the same ROM and options reports READY from
+  the existing manifest, exactly as it did when the build finished.
+- The game now logs WHY a persisted cache was rejected at boot: the full cache
+  identity, the resolved cache dir, a `build.info` sidecar written at build
+  time (identity + components + timestamp), the per-component diff against
+  the live identity, and the exact rejection reason (`identity_mismatch`,
+  `no_manifest`, `corrupt_manifest`, `file_missing`, `total_mismatch`). Any
+  remaining cache-rejection reports on Android can now be pinned down from the
+  logcat output instead of guessed at.
+
 ## [1.4.1] - 2026-08-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,31 @@
 
 ### Fixed
 
-- The map cache no longer rebuilds on every app launch (Android). The cache
-  identity now snapshots once at build start (`begin()`), so every payload
-  file and the manifest share a single build-session identity even if a live
-  identity component (like the VOID FILL setting) changes mid-build -- the
-  manifest can no longer be stamped with a different identity than the files
-  it describes. A relaunch with the same ROM and options reports READY from
-  the existing manifest, exactly as it did when the build finished.
-- The game now logs WHY a persisted cache was rejected at boot: the full cache
-  identity, the resolved cache dir, a `build.info` sidecar written at build
-  time (identity + components + timestamp), the per-component diff against
-  the live identity, and the exact rejection reason (`identity_mismatch`,
-  `no_manifest`, `corrupt_manifest`, `file_missing`, `total_mismatch`). Any
-  remaining cache-rejection reports on Android can now be pinned down from the
-  logcat output instead of guessed at.
+- The map cache no longer asks to rebuild on every launch. The game was
+  checking the cache with default settings before your save loaded, so a
+  save that used a different VOID FILL looked "stale" every time -- even
+  when the cache matched your settings perfectly. The check now runs after
+  your save (and its options) are loaded, and the BUILD NOW? prompt appears
+  over the world instead of the title screen.
+- Interrupted builds now resume. If a build is cut short (the app was
+  backgrounded, the battery died, a crash), the next launch continues from
+  where it stopped instead of starting over or prompting forever.
+- The map cache now refreshes itself once when you update to 1.4.2 (the
+  cache now remembers more detail about your game data, so old files are
+  rebuilt a single time, in the background or on demand).
+- Windows: updating the cache info file no longer fails silently, which
+  could leave the game asking for a rebuild every launch.
+- When a build fails, the game now tells you WHY (a full SD card, a
+  read-only folder) instead of a generic "verification failed".
+- The cache folder is created more reliably: the game tries the normal
+  save-system folder first, then falls back to system commands, and
+  double-checks the folder can actually be written to before using it.
+  **CACHE STATUS** now shows which method was used (LOVE FS / MKDIR / NONE).
+- If the cache folder can't be set up, the game now retries instead of
+  quietly disabling the cache for the whole session.
+- Boot logging: when the cache is rejected, the game log now explains
+  exactly why, which makes "it rebuilds every time" reports much easier to
+  diagnose.
 
 ## [1.4.1] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ python3 tools/modkit.py pack mods/potato_voxel
 - **OPTIONS → PREBUILD CACHE** cooperatively builds every map's body and full
   terrain variant, including water and auxiliary meshes. The game checks the
   complete cache at boot and shows **READY** when every current job is present.
-  When the cache is incomplete, selecting **CONTINUE** or **NEW GAME** offers
-  to build it first; choosing NO starts normally. The progress screen can be
+  When the cache is incomplete, **CONTINUE** or **NEW GAME** offers to build it
+  after the save loads (the check runs against the save's actual options, so a
+  matching cache never prompts); choosing NO starts normally. An interrupted
+  build resumes from the jobs it already finished. The progress screen can be
   cancelled, and runtime GPU meshes are released after each map while the disk
   cache remains. The action is available on both desktop and the potato
   profile.

--- a/lib/CachePrebuild.lua
+++ b/lib/CachePrebuild.lua
@@ -76,6 +76,56 @@ function Prebuild.bootstrap(game)
             slot = nil, done = ready and #jobs or done, total = #jobs,
             game = nil, startedAt = nil, eta = nil, ready = ready,
             failed = false, error = nil, completed = {} }
+  -- Boot diagnostics: log the full cache identity, the resolved cache dir,
+  -- and -- when the cache was rejected -- exactly why, plus how it compares
+  -- to the build.info sidecar written at build time. This is the only window
+  -- into a persistent cache rejection on real hardware.
+  local parts = MeshCache.identityParts()
+  local build = MeshCache.readBuildInfo()
+  print("[PotatoVoxel] cache identity: " .. MeshCache.identity())
+  print("[PotatoVoxel]   format=" .. tostring(parts.format)
+    .. " version=" .. tostring(parts.version)
+    .. " activeVersion=" .. tostring(parts.activeVersion)
+    .. " profile=" .. tostring(parts.profile)
+    .. " dataKey=" .. tostring(parts.dataKey)
+    .. " voidFill=" .. tostring(parts.voidFill))
+  print("[PotatoVoxel] cache dir: " .. tostring(MeshCache.dir()))
+  print("[PotatoVoxel] cache ready: " .. tostring(ready) .. " (" .. done
+    .. "/" .. #jobs .. ")")
+  if build then
+    print("[PotatoVoxel] build.info: identity=" .. tostring(build.identity)
+      .. " version=" .. tostring(build.version)
+      .. " activeVersion=" .. tostring(build.activeVersion)
+      .. " profile=" .. tostring(build.profile)
+      .. " dataKey=" .. tostring(build.dataKey)
+      .. " voidFill=" .. tostring(build.voidFill)
+      .. " builtAt=" .. tostring(build.builtAt))
+    if ready then
+      print("[PotatoVoxel]   build identity matches live identity")
+    else
+      local diffs = MeshCache.identityDiff(build.identity, MeshCache.identity())
+      print("[PotatoVoxel]   build identity differs in: "
+        .. (#diffs > 0 and table.concat(diffs, ",") or "?"))
+    end
+  end
+  if not ready then
+    local failure = MeshCache.getLastFailure()
+    if failure then
+      print("[PotatoVoxel] cache rejected: " .. tostring(failure.reason))
+      if failure.expected then
+        print("[PotatoVoxel]   expected=" .. tostring(failure.expected))
+      end
+      if failure.actual then
+        print("[PotatoVoxel]   actual=" .. tostring(failure.actual))
+      end
+      if failure.diffs and #failure.diffs > 0 then
+        print("[PotatoVoxel]   diffs=" .. table.concat(failure.diffs, ","))
+      end
+      if failure.job then
+        print("[PotatoVoxel]   job=" .. tostring(failure.job))
+      end
+    end
+  end
   return ready
 end
 

--- a/lib/CachePrebuild.lua
+++ b/lib/CachePrebuild.lua
@@ -72,10 +72,17 @@ function Prebuild.bootstrap(game)
   MeshCache.configure(data)
   local jobs = Prebuild.enumerate(data and data.maps)
   local ready, done = MeshCache.ready(jobs)
+  -- Not READY is no longer "start from zero": a build interrupted
+  -- mid-session (F3) left complete atomic payloads behind, and a rescan
+  -- of the actual files recovers exactly which jobs survived. Those
+  -- become the resume set -- start() skips them and only the missing
+  -- remainder gets rebuilt.
+  local completed = {}
+  if not ready then completed, done = MeshCache.scanComplete(jobs) end
   state = { running = false, cancelled = false, maps = jobs, index = 0,
             slot = nil, done = ready and #jobs or done, total = #jobs,
             game = nil, startedAt = nil, eta = nil, ready = ready,
-            failed = false, error = nil, completed = {} }
+            failed = false, error = nil, completed = completed }
   -- Boot diagnostics: log the full cache identity, the resolved cache dir,
   -- and -- when the cache was rejected -- exactly why, plus how it compares
   -- to the build.info sidecar written at build time. This is the only window
@@ -125,6 +132,10 @@ function Prebuild.bootstrap(game)
         print("[PotatoVoxel]   job=" .. tostring(failure.job))
       end
     end
+    if done > 0 then
+      print("[PotatoVoxel]   resumable: " .. done .. "/" .. #jobs
+        .. " jobs already complete")
+    end
   end
   return ready
 end
@@ -162,7 +173,7 @@ local function finish(cancelled)
     state.ready = MeshCache.writeManifest(state.completed, state.total)
     if not state.ready then
       state.failed = true
-      state.error = "manifest write failed"
+      state.error = MeshCache.saveError() or "manifest write failed"
     end
   end
   state.running, state.cancelled = false, cancelled or false
@@ -198,10 +209,21 @@ function Prebuild.start(game)
   local jobs = Prebuild.enumerate(data and data.maps)
   if #jobs == 0 or not MeshCache.available() then return false end
   MeshCache.begin()
-  state = { running = true, cancelled = false, maps = jobs, index = 1,
-            slot = nil, done = 0, total = #jobs, game = game,
+  -- RESUME (F3): jobs the boot scan found complete are skipped, so a
+  -- prebuild interrupted mid-session finishes the remainder instead of
+  -- rebuilding everything from zero. A fresh build (empty completed)
+  -- starts at the first job as before.
+  local completed = state.completed or {}
+  local index = 1
+  for i, job in ipairs(jobs) do
+    local key = tostring(job.id) .. "/" .. tostring(job.slot)
+    if not completed[key] then index = i; break end
+    index = i + 1
+  end
+  state = { running = true, cancelled = false, maps = jobs, index = index,
+            slot = nil, done = index - 1, total = #jobs, game = game,
             startedAt = now(), eta = nil, ready = false,
-            failed = false, error = nil, completed = {} }
+            failed = false, error = nil, completed = completed }
   return true
 end
 
@@ -219,8 +241,43 @@ function Prebuild.wipe(game)
     ChunkMesher.invalidate()
     state.ready, state.cancelled, state.failed = false, false, false
     state.done, state.total, state.error = 0, #jobs, nil
+    state.completed = {}
   end
   return ok
+end
+
+local function countKeys(table_)
+  local count = 0
+  for _ in pairs(table_ or {}) do count = count + 1 end
+  return count
+end
+
+-- Re-evaluate readiness against the live identity and files, and update
+-- the resume set. Called after the engine applies a save's real options
+-- (CONTINUE's restoreSave / NEW GAME's onNewGame): the game.ready-time
+-- check ran under the skeleton save's defaults, and a player's VOID FILL
+-- choice would otherwise read as a stale cache on every launch (F1).
+function Prebuild.refresh(game)
+  if state.running then return end
+  local data = game and game.data
+  local jobs = Prebuild.enumerate(data and data.maps)
+  if #jobs ~= state.total then
+    -- the dataset changed under us (hot reload): full re-bootstrap
+    return Prebuild.bootstrap(game)
+  end
+  local ready, done = MeshCache.ready(jobs)
+  state.ready = ready
+  if ready then
+    state.done = #jobs
+    state.failed, state.error = false, nil
+    state.completed = {}
+  else
+    local completed = MeshCache.scanComplete(jobs)
+    state.completed = completed
+    state.done = countKeys(completed)
+  end
+  state.total = #jobs
+  return ready
 end
 
 -- Keep the options-row decision separate from the UI so the READY path can be
@@ -251,12 +308,18 @@ function Prebuild.update()
   if jobStatus == "pending" then return end
   if jobStatus ~= "complete" or not MeshCache.verifyJob(state.slot, job.slot) then
     state.failed = true
-    state.error = jobStatus or "cache verification failed"
+    state.error = jobStatus
+      or MeshCache.saveError()
+      or "cache verification failed"
     finish(false)
     return
   end
   state.completed[tostring(job.id) .. "/" .. tostring(job.slot)] =
     MeshCache.jobRecord(state.slot, job.slot)
+  -- Update the manifest per completed job (F3): an interrupted build now
+  -- leaves a manifest naming exactly the jobs whose files survived, so
+  -- the next boot resumes instead of prompting forever.
+  MeshCache.writeProgress(state.completed, state.total)
   releaseMap(job.id, state.game)
   state.done = state.done + 1
   state.index = state.index + 1

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -62,6 +62,19 @@ local dataKey = "unconfigured"
 local dirty = false
 local compression = "unknown"
 local MANIFEST = "cache.info"
+local BUILD_INFO = "build.info"
+-- Populated by ready() whenever it returns false, so a caller (the boot
+-- path) can report exactly WHY the cache was rejected -- an identity drift
+-- between the build session and this launch, or payload files that did not
+-- survive. nil after a successful ready().
+local lastFailure = nil
+-- Snapshot of identity() captured at begin(): every payload file and the
+-- manifest written by that build session share ONE identity even if a live
+-- component (voidFill) changes mid-build. Cleared when the build finishes.
+local buildIdentity = nil
+-- Components of the build-session identity, captured at begin() for the
+-- build.info sidecar so a later launch can compare against the live identity.
+local buildParts = nil
 
 -- Bump when the meshing algorithm changes the vertex/UV output, so a
 -- cache written by an older build is never trusted by a newer one. (The
@@ -187,18 +200,57 @@ local function activeVersion()
   return "red"
 end
 
-local function identity()
+local function identityParts()
   local okTR, TileRenderer = pcall(require, "src.render.TileRenderer")
   local voidFill = (okTR and TileRenderer and TileRenderer.voidFill) or "trees"
   local profile = Brick.isBrick() and "b" or "f"
-  return table.concat({ "PVMC1", MeshCache.GEOMETRY_VERSION, activeVersion(),
-                        profile, dataKey, tostring(voidFill) }, "|")
+  return {
+    format = "PVMC1",
+    version = MeshCache.GEOMETRY_VERSION,
+    activeVersion = activeVersion(),
+    profile = profile,
+    dataKey = dataKey,
+    voidFill = tostring(voidFill),
+  }
+end
+
+local function identity()
+  local parts = identityParts()
+  return table.concat({ parts.format, parts.version, parts.activeVersion,
+                        parts.profile, parts.dataKey, parts.voidFill }, "|")
+end
+
+-- Compares two identity strings (expected vs actual) and returns the names of
+-- the components that differ, so diagnostics can pinpoint a drift.
+local IDENTITY_COMPONENTS = { "format", "version", "activeVersion", "profile",
+                              "dataKey", "voidFill" }
+
+local function splitIdentity(id)
+  local parts = {}
+  for part in tostring(id):gmatch("([^|]*)") do
+    if part ~= "" then parts[#parts + 1] = part end
+  end
+  return parts
+end
+
+local function identityDiff(expected, actual)
+  local e = splitIdentity(expected)
+  local a = splitIdentity(actual)
+  local diffs = {}
+  for i, name in ipairs(IDENTITY_COMPONENTS) do
+    if e[i] ~= a[i] then diffs[#diffs + 1] = name end
+  end
+  return diffs
 end
 
 function MeshCache.configure(data)
   dataKey = datasetRevision(data)
   dirty = false
   compression = "unknown"
+  -- A new configuration starts a fresh session: drop any snapshot from a
+  -- previous build so live identity() is authoritative until begin() runs.
+  buildIdentity = nil
+  buildParts = nil
 end
 
 function MeshCache.isDirty()
@@ -319,6 +371,13 @@ end
 function MeshCache.begin()
   dirty = true
   compression = "unknown"
+  -- Snapshot the identity at the START of a build session. Every payload
+  -- file and the manifest written by this session share this one identity,
+  -- even if a live component (e.g. voidFill) changes mid-build. This removes
+  -- the "identity drifted between begin() and finish()" failure class.
+  buildIdentity = identity()
+  buildParts = identityParts()
+  lastFailure = nil
   local path = manifestPath()
   if path then os.remove(path) end
 end
@@ -333,7 +392,8 @@ local function fingerprint(map, slot)
   local tileset = (map.tileset and map.tileset.image) or "?"
   local trueColor = (map.tileset and map.tileset.trueColor) and "1" or "0"
   local atlas = (map.renderer and map.renderer.gbcAtlas) and "g" or "s"
-  return identity() .. "|" .. tostring(map.id) .. "|" .. tostring(slot) .. "|"
+  local id = buildIdentity or identity()
+  return id .. "|" .. tostring(map.id) .. "|" .. tostring(slot) .. "|"
          .. tileset .. "|" .. trueColor .. "|" .. atlas
 end
 
@@ -750,11 +810,15 @@ function MeshCache.verifyJob(map, slot)
      and safeValidPayload(dir .. "/" .. record.aux, record.auxFp, "aux")
 end
 
+-- Returns (manifest, failReason, manifestIdentity) where failReason is nil on
+-- success, or one of "no_dir", "missing", "format", "identity", "records".
+-- manifestIdentity is the identity string read from the manifest header, so
+-- an identity mismatch can be diffed against the live identity.
 local function readManifest()
   local path = manifestPath()
-  if not path then return nil end
+  if not path then return nil, "no_dir" end
   local text = readFile(path)
-  if not text then return nil end
+  if not text then return nil, "missing" end
   local lines = {}
   for line in text:gmatch("[^\n]+") do lines[#lines + 1] = line end
   local format, manifestIdentity, total
@@ -762,41 +826,85 @@ local function readManifest()
     format, manifestIdentity, total =
       lines[1]:match("^(%S+)%s+(%S+)%s+(%d+)$")
   end
-  if format ~= "PVMC1" or manifestIdentity ~= identity() then return nil end
+  if format ~= "PVMC1" then return nil, "format" end
+  if manifestIdentity ~= identity() then
+    return nil, "identity", manifestIdentity
+  end
   local records = {}
   for i = 2, #lines do
     local key, terrain, terrainFp, water, waterFp, aux, auxFp =
       lines[i]:match("^job\t([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)$")
-    if not key then return nil end
+    if not key then return nil, "records" end
     records[key] = { key = key, terrain = terrain, terrainFp = terrainFp,
                      water = water, waterFp = waterFp, aux = aux, auxFp = auxFp }
   end
   return { total = tonumber(total), records = records }
 end
 
+local function setLastFailure(reason, detail)
+  lastFailure = { reason = reason, expected = identity() }
+  if detail then
+    for k, v in pairs(detail) do lastFailure[k] = v end
+  end
+end
+
 function MeshCache.ready(jobs)
-  if dirty or not MeshCache.available() then return false, 0 end
-  local manifest = readManifest()
-  if not manifest or manifest.total ~= #jobs then
+  if dirty or not MeshCache.available() then
+    setLastFailure(dirty and "dirty" or "unavailable")
+    return false, 0
+  end
+  local manifest, failReason, manifestIdentity = readManifest()
+  if not manifest then
+    if failReason == "identity" then
+      -- The definitive diagnostic: the manifest was built under a different
+      -- identity than the live one. Report it as the primary reason; a
+      -- self-heal scan can only succeed if files were rebuilt under the live
+      -- identity, and even then the mismatch is what a user needs to know.
+      setLastFailure("identity_mismatch", {
+        actual = manifestIdentity,
+        diffs = identityDiff(manifestIdentity, identity()),
+      })
+    elseif failReason == "missing" or failReason == "no_dir" then
+      setLastFailure("no_manifest")
+    else
+      setLastFailure("corrupt_manifest", { reason = failReason })
+    end
     local dir = MeshCache.dir()
     local records, done = {}, 0
     for _, job in ipairs(jobs or {}) do
       local record = scanJob(job, dir)
-      if not record then return false, done end
+      if not record then
+        -- Preserve the identity_mismatch diagnostic when present (the scan
+        -- failing against live identity is the expected consequence).
+        if lastFailure.reason ~= "identity_mismatch" then
+          setLastFailure("file_missing", { job = tostring(job.id) .. "/"
+            .. tostring(job.slot) })
+        end
+        return false, done
+      end
       records[record.key] = record
       done = done + 1
     end
     if done == #jobs and MeshCache.writeManifest(records, #jobs) then
+      lastFailure = nil
       return true, done
     end
     return false, done
+  end
+  if manifest.total ~= #jobs then
+    setLastFailure("total_mismatch",
+      { actual = manifest.total, jobs = #jobs })
+    return false, 0
   end
   local dir = MeshCache.dir()
   local done = 0
   for _, job in ipairs(jobs or {}) do
     local key = tostring(job.id) .. "/" .. tostring(job.slot)
     local record = manifest.records[key]
-    if not record then return false, done end
+    if not record then
+      setLastFailure("file_missing", { job = key })
+      return false, done
+    end
     local ok = safeValidHeader(dir .. "/" .. record.terrain, record.terrainFp)
            and safeValidHeader(dir .. "/" .. record.water, record.waterFp)
            and safeValidHeader(dir .. "/" .. record.aux, record.auxFp)
@@ -804,22 +912,47 @@ function MeshCache.ready(jobs)
       local records, scanned = {}, 0
       for _, candidate in ipairs(jobs or {}) do
         local migrated = scanJob(candidate, dir)
-        if not migrated then return false, done end
+        if not migrated then
+          setLastFailure("file_missing", { job = key })
+          return false, done
+        end
         records[migrated.key] = migrated
         scanned = scanned + 1
       end
       if scanned == #jobs and MeshCache.writeManifest(records, #jobs) then
+        lastFailure = nil
         return true, scanned
       end
+      setLastFailure("file_missing", { job = key })
       return false, done
     end
     done = done + 1
   end
   if done == #jobs then
+    lastFailure = nil
     updateCompression(manifest.records, dir)
     return true, done
   end
+  setLastFailure("total_mismatch", { actual = manifest.total, jobs = #jobs })
   return false, done
+end
+
+-- Writes the build.info sidecar: the identity (and its components) that the
+-- cache was actually built with, plus a timestamp. Read at the next launch so
+-- a persistent cache rejection can be diffed against the live identity.
+local function writeBuildInfo(id, parts)
+  local dir = MeshCache.dir()
+  if not dir then return end
+  writeFile(dir .. "/" .. BUILD_INFO, table.concat({
+    "identity=" .. id,
+    "format=" .. parts.format,
+    "version=" .. tostring(parts.version),
+    "activeVersion=" .. tostring(parts.activeVersion),
+    "profile=" .. parts.profile,
+    "dataKey=" .. parts.dataKey,
+    "voidFill=" .. parts.voidFill,
+    "builtAt=" .. tostring(os.time and os.time() or 0),
+  }, "\n") .. "\n")
 end
 
 function MeshCache.writeManifest(records, total)
@@ -827,7 +960,11 @@ function MeshCache.writeManifest(records, total)
   if not path or type(records) ~= "table" then return false end
   local keys = sortedKeys(records)
   if #keys ~= total then return false end
-  local lines = { ("PVMC1\t%s\t%d"):format(identity(), total) }
+  -- During an active build the manifest carries the begin()-time snapshot so
+  -- it matches every payload file exactly; outside a build (self-heal rescan)
+  -- it carries the live identity the scan was validated against.
+  local id = dirty and buildIdentity or identity()
+  local lines = { ("PVMC1\t%s\t%d"):format(id, total) }
   for _, key in ipairs(keys) do
     local record = records[key]
     lines[#lines + 1] = table.concat({ "job", record.key, record.terrain,
@@ -836,7 +973,12 @@ function MeshCache.writeManifest(records, total)
   end
   local ok = writeFile(path, table.concat(lines, "\n") .. "\n")
   if ok then
+    writeBuildInfo(id, buildParts or identityParts())
     dirty = false
+    -- The build session is over: drop the snapshot so any later self-heal
+    -- scan validates against the LIVE identity, not the stale build one.
+    buildIdentity = nil
+    buildParts = nil
     updateCompression(records, MeshCache.dir())
   end
   return ok
@@ -1059,5 +1201,36 @@ MeshCache.mkdirCommands = mkdirCommands
 -- indexed terrain/water payloads (brick.11+)
 MeshCache.encodeIndexed = encodeIndexed
 MeshCache.decodeIndexed = decodeIndexed
+-- Diagnostics: populated by ready() on failure, cleared on success. Getter
+-- so callers always read the CURRENT failure (the local is reassigned).
+function MeshCache.getLastFailure()
+  return lastFailure
+end
+-- Identity components / diff helpers, exported for boot diagnostics.
+MeshCache.identityParts = identityParts
+MeshCache.identityDiff = identityDiff
+
+-- Read the build.info sidecar written at build time (nil when absent).
+function MeshCache.readBuildInfo()
+  local dir = MeshCache.dir()
+  if not dir then return nil end
+  local text = readFile(dir .. "/" .. BUILD_INFO)
+  if not text then return nil end
+  local info = {}
+  for line in text:gmatch("[^\n]+") do
+    local k, v = line:match("^([^=]+)=(.*)$")
+    if k then info[k] = v end
+  end
+  return info
+end
+
+-- A build-time snapshot of what this cache was built under, for the
+-- CachePrebuild bootstrap log: the full identity and its components.
+function MeshCache.buildInfoSnapshot()
+  if not buildParts then return nil end
+  local info = { identity = buildIdentity }
+  for k, v in pairs(buildParts) do info[k] = tostring(v) end
+  return info
+end
 
 return MeshCache

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -75,6 +75,11 @@ local buildIdentity = nil
 -- Components of the build-session identity, captured at begin() for the
 -- build.info sidecar so a later launch can compare against the live identity.
 local buildParts = nil
+-- Per-session write-error tracking (F5): every saveTerrain/saveWater/saveAux
+-- write failure is remembered, so a build that dies to a full SD card or a
+-- read-only folder says WHY instead of "cache verification failed".
+local lastSaveError = nil
+local saveFailures = 0
 
 -- Bump when the meshing algorithm changes the vertex/UV output, so a
 -- cache written by an older build is never trusted by a newer one. (The
@@ -181,6 +186,9 @@ local function datasetRevision(data)
       hash = hashString(hash, direction)
       hash = hashString(hash, connection.map)
       hash = hashString(hash, connection.offset)
+      -- hashed defensively: no shipped dataset carries it today, but a
+      -- walkable-capped connection would change the meshed strip
+      hash = hashString(hash, connection.walkable)
     end
   end
   local tilesets = data and data.tilesets or {}
@@ -191,6 +199,15 @@ local function datasetRevision(data)
     hash = hashString(hash, tileset.trueColor)
     hash = hashString(hash, tileset.tilesPerRow)
     hash = hashValues(hash, tileset.blocks)
+    -- The tileset fields the mesher reads but the revision used to skip:
+    -- a dataset that moved which tiles are walkable, counters, doors,
+    -- warps or grass would have produced identical geometry from stale
+    -- cache files (F6).
+    hash = hashValues(hash, tileset.walkable)
+    hash = hashValues(hash, tileset.counterTiles)
+    hash = hashValues(hash, tileset.doorTiles)
+    hash = hashValues(hash, tileset.warpTiles)
+    hash = hashString(hash, tileset.grassTile)
   end
   return tostring(hash)
 end
@@ -266,7 +283,9 @@ MeshCache.identity = identity
 -- ---------------------------------------------------------- availability
 
 local dirTried = false
+local dirTriedAt = 0            -- os.clock() of the last attempt
 local cacheDir = false          -- resolved once; false when unusable
+local dirBackend = nil          -- how the dir was created: "love" or "mkdir"
 
 -- The shell commands that create the cache directory tree. Windows cmd has
 -- no `mkdir -p`: it cannot create missing parents and errors when the
@@ -303,21 +322,56 @@ function MeshCache.available()
   return MeshCache.dir() ~= nil
 end
 
+-- Real io write probe: the cache writes every payload through io.*, so an
+-- io round-trip is the ground truth for "usable", whatever backend made
+-- the directory. Exported so the headless suite can probe paths directly.
+local function probeWritable(dir)
+  if not dir or dir == "" then return false end
+  local probe = dir .. "/.write_probe"
+  local f = io.open(probe, "wb")
+  if not f then return false end
+  local ok = f:write("x") ~= nil
+  f:close()
+  os.remove(probe)
+  return ok
+end
+
 -- The cache directory, resolved and created on first use. On the Brick
 -- this is the portable (SD-card) folder; everywhere else it is the LÖVE
 -- save directory -- the engine's own io-rooted save location (on macOS
 -- that resolves to ~/Library/Application Support/LOVE/<identity>/, the
 -- folder the engine actually reads). nil when no writable root exists
 -- (then everything no-ops).
+--
+-- Creation tries love.filesystem.createDirectory FIRST -- it makes the
+-- whole tree on desktop and needs no shell -- and only falls back to the
+-- mkdir command list (the only option in portable mode, whose SD-card
+-- folder sits outside love.filesystem's root). The resolved directory is
+-- then verified with a real io write probe, so a folder that can be
+-- created but not written to is caught here instead of mid-build.
+--
+-- A FAILURE is retried, not cached forever: one early os.execute hiccup
+-- (a mid-boot SD-card mount, a shell under load) used to disable the
+-- cache for the whole session. A success is cached for the session; a
+-- failure only suppresses retries for one second, so the next boot check
+-- or save re-attempts the mkdir instead of silently giving up.
 function MeshCache.dir()
-  if dirTried then return cacheDir end
+  if cacheDir then return cacheDir end
+  local clock = os.clock
+  local now = clock and clock() or 0
+  if dirTried and now - dirTriedAt < 1 then return nil end
   dirTried = true
+  dirTriedAt = now
   cacheDir = false
+  dirBackend = nil
   local okBase, base
+  local portable = false
   if SaveData then
     okBase, base = pcall(function() return SaveData.portableBaseDir() end)
   end
-  if not (okBase and base) then
+  if okBase and base then
+    portable = true
+  else
     -- Desktop / non-portable: fall back to the LÖVE save directory. No
     -- platform branches -- the Brick keeps its SD-card portable root,
     -- everything else lands here.
@@ -329,15 +383,39 @@ function MeshCache.dir()
   local sep = package.config:sub(1, 1)
   local d = base .. sep .. "mod-derived" .. sep .. "potato_voxel"
             .. sep .. "meshes"
-  -- io.* cannot create missing parents; mkdir the tree like the engine's
-  -- portable filesystem does. Failure stays a silent no-op (nil above).
+  -- 1) love.filesystem.createDirectory: whole tree, no shell. Portable
+  -- mode skips it -- the SD card is outside love.filesystem's root.
+  if not portable and love and love.filesystem
+     and love.filesystem.createDirectory then
+    local created = pcall(love.filesystem.createDirectory,
+                          "mod-derived/potato_voxel/meshes")
+    if created and probeWritable(d) then
+      cacheDir = d
+      dirBackend = "love"
+      return d
+    end
+  end
+  -- 2) mkdir fallback -- the only path in portable mode, and the retry
+  -- path when love.filesystem was unavailable or the folder unwritable.
+  -- io.* cannot create missing parents, so mkdir the tree like the
+  -- engine's portable filesystem does. Failure stays a silent no-op.
   for _, command in ipairs(mkdirCommands(d, sep)) do
     local ok = os.execute(command)
     if not (ok == true or ok == 0) then return nil end
   end
+  if not probeWritable(d) then return nil end
   cacheDir = d
+  dirBackend = "mkdir"
   return d
 end
+
+-- Which backend created the cache directory: "love" (love.filesystem),
+-- "mkdir" (shell commands), or nil (unresolved/unavailable). Shown in the
+-- CACHE STATUS details box.
+function MeshCache.dirBackend()
+  return dirBackend
+end
+MeshCache.probeWritable = probeWritable
 
 -- ------------------------------------------------------------- storage io
 
@@ -359,6 +437,15 @@ local function writeFile(path, data)
   f:close()
   if not ok then os.remove(tmp) return false end
   local ok2 = os.rename(tmp, path)
+  if not ok2 and package.config:sub(1, 1) == "\\" then
+    -- MSVCRT's rename fails when the destination exists (POSIX replaces
+    -- it, which is why this never runs off Windows). The self-heal path
+    -- rewrites cache.info over an existing file every boot it has to
+    -- recover, so on Windows that recovery used to fail silently and the
+    -- prompt came back on EVERY launch. Drop the target and retry once.
+    os.remove(path)
+    ok2 = os.rename(tmp, path)
+  end
   if not ok2 then os.remove(tmp) return false end
   return true
 end
@@ -378,8 +465,19 @@ function MeshCache.begin()
   buildIdentity = identity()
   buildParts = identityParts()
   lastFailure = nil
-  local path = manifestPath()
-  if path then os.remove(path) end
+  lastSaveError = nil
+  saveFailures = 0
+  -- The manifest is KEPT, not deleted. Deleting it here meant a build
+  -- interrupted before finish() (an Android background kill, a battery
+  -- pull) left no manifest behind at all -- and the next boot saw only
+  -- orphaned payloads and prompted for a rebuild on every single launch.
+  -- Keeping it is safe: payload writes are atomic (tmp + rename), so the
+  -- files a mid-build death leaves behind are each EITHER the old
+  -- complete payload or the new complete payload, and the fingerprint
+  -- check accepts whichever mix survived when the identity matches.
+  -- Prebuild overwrites the manifest per job (writeProgress) so even the
+  -- very first build leaves a manifest describing exactly the jobs that
+  -- finished.
 end
 
 -- ------------------------------------------------------------- fingerprint
@@ -901,40 +999,55 @@ function MeshCache.ready(jobs)
   for _, job in ipairs(jobs or {}) do
     local key = tostring(job.id) .. "/" .. tostring(job.slot)
     local record = manifest.records[key]
-    if not record then
-      setLastFailure("file_missing", { job = key })
-      return false, done
-    end
-    local ok = safeValidHeader(dir .. "/" .. record.terrain, record.terrainFp)
+    local ok = record ~= nil
+           and safeValidHeader(dir .. "/" .. record.terrain, record.terrainFp)
            and safeValidHeader(dir .. "/" .. record.water, record.waterFp)
            and safeValidHeader(dir .. "/" .. record.aux, record.auxFp)
-    if not ok then
-      local records, scanned = {}, 0
-      for _, candidate in ipairs(jobs or {}) do
-        local migrated = scanJob(candidate, dir)
-        if not migrated then
-          setLastFailure("file_missing", { job = key })
-          return false, done
-        end
-        records[migrated.key] = migrated
-        scanned = scanned + 1
-      end
-      if scanned == #jobs and MeshCache.writeManifest(records, #jobs) then
-        lastFailure = nil
-        return true, scanned
-      end
-      setLastFailure("file_missing", { job = key })
-      return false, done
-    end
-    done = done + 1
+    if ok then done = done + 1 end
   end
   if done == #jobs then
     lastFailure = nil
     updateCompression(manifest.records, dir)
     return true, done
   end
-  setLastFailure("total_mismatch", { actual = manifest.total, jobs = #jobs })
-  return false, done
+  -- Some records are missing or invalid -- a partial manifest from a build
+  -- interrupted before finish(), a file that did not survive -- so rescan
+  -- the actual files. Payload writes are atomic, so whatever survived is a
+  -- COMPLETE old-or-new payload and the scan accepts the mix. A full rescan
+  -- self-heals the manifest (READY); a partial one reports how many jobs
+  -- are done so the prebuild can RESUME instead of restarting from zero.
+  local records, scanned = {}, 0
+  for _, candidate in ipairs(jobs or {}) do
+    local migrated = scanJob(candidate, dir)
+    if migrated then
+      records[migrated.key] = migrated
+      scanned = scanned + 1
+    end
+  end
+  if scanned == #jobs and MeshCache.writeManifest(records, #jobs) then
+    lastFailure = nil
+    return true, scanned
+  end
+  setLastFailure("file_missing", { done = scanned, jobs = #jobs })
+  return false, scanned
+end
+
+-- The records of every job whose three payload files all survive with the
+-- live identity -- the resume set a boot can hand back to a prebuild that
+-- was interrupted mid-session. File-level, like scanJob, so a manifest is
+-- neither required nor trusted here.
+function MeshCache.scanComplete(jobs)
+  local dir = MeshCache.dir()
+  if not dir then return {}, 0 end
+  local records, done = {}, 0
+  for _, job in ipairs(jobs or {}) do
+    local record = scanJob(job, dir)
+    if record then
+      records[record.key] = record
+      done = done + 1
+    end
+  end
+  return records, done
 end
 
 -- Writes the build.info sidecar: the identity (and its components) that the
@@ -955,11 +1068,16 @@ local function writeBuildInfo(id, parts)
   }, "\n") .. "\n")
 end
 
-function MeshCache.writeManifest(records, total)
+-- The shared manifest writer: records keyed by job key, `total` the full
+-- job count. writeProgress lets a build UPDATE the manifest after every
+-- completed job (records may be fewer than total), so a build interrupted
+-- before finish() still leaves a manifest naming exactly the jobs whose
+-- files survived. Returns (ok, writtenIdentity).
+local function writeManifestLines(records, total)
   local path = manifestPath()
   if not path or type(records) ~= "table" then return false end
   local keys = sortedKeys(records)
-  if #keys ~= total then return false end
+  if #keys > total then return false end
   -- During an active build the manifest carries the begin()-time snapshot so
   -- it matches every payload file exactly; outside a build (self-heal rescan)
   -- it carries the live identity the scan was validated against.
@@ -971,7 +1089,23 @@ function MeshCache.writeManifest(records, total)
       record.terrainFp, record.water, record.waterFp, record.aux,
       record.auxFp }, "\t")
   end
-  local ok = writeFile(path, table.concat(lines, "\n") .. "\n")
+  return writeFile(path, table.concat(lines, "\n") .. "\n"), id
+end
+
+-- Per-job progress manifest (F3): the prebuild calls this after each job
+-- so an interrupted build leaves a manifest instead of a hole the boot
+-- prompts about forever.
+function MeshCache.writeProgress(records, total)
+  local ok, id = writeManifestLines(records, total)
+  if ok then
+    writeBuildInfo(id, buildParts or identityParts())
+  end
+  return ok
+end
+
+function MeshCache.writeManifest(records, total)
+  if not records or #sortedKeys(records) ~= total then return false end
+  local ok, id = writeManifestLines(records, total)
   if ok then
     writeBuildInfo(id, buildParts or identityParts())
     dirty = false
@@ -986,24 +1120,45 @@ end
 
 -- ------------------------------------------------------------ save/load
 
+-- A save that cannot write is now SURFACED, not swallowed (F5): the old
+-- pcall only caught thrown errors, so a writeFile that returned false --
+-- a full SD card, a read-only folder, a missing rename target -- vanished
+-- into the next "cache verification failed". The per-session reason lands
+-- in lastSaveError, which Prebuild copies into its failure message.
+local function recordSaveFailure(kind, detail)
+  saveFailures = saveFailures + 1
+  lastSaveError = kind .. (detail and (": " .. tostring(detail)) or "")
+  return false
+end
+
 function MeshCache.saveTerrain(map, slot, buf, n, idx, m)
-  if not MeshCache.dir() then return end
-  local ok = pcall(function()
+  if not MeshCache.dir() then return false end
+  local path = fileFor(map, slot, "terrain")
+  local ok, result = pcall(function()
     local fp = fingerprint(map, slot)
-    writeFile(fileFor(map, slot, "terrain"),
-              packPayload(fp, encodeIndexed(n, buf, m, idx)))
+    return writeFile(path, packPayload(fp, encodeIndexed(n, buf, m, idx)))
   end)
-  if not ok then os.remove(fileFor(map, slot, "terrain") .. ".tmp") end
+  if not ok then
+    os.remove(path .. ".tmp")
+    return recordSaveFailure("terrain", result)
+  end
+  if result ~= true then return recordSaveFailure("terrain") end
+  return true
 end
 
 function MeshCache.saveWater(map, slot, buf, n, idx, m)
-  if not MeshCache.dir() then return end
-  local ok = pcall(function()
+  if not MeshCache.dir() then return false end
+  local path = fileFor(map, slot, "water")
+  local ok, result = pcall(function()
     local fp = fingerprint(map, slot .. "Water")
-    writeFile(fileFor(map, slot, "water"),
-              packPayload(fp, encodeIndexed(n, buf, m, idx)))
+    return writeFile(path, packPayload(fp, encodeIndexed(n, buf, m, idx)))
   end)
-  if not ok then os.remove(fileFor(map, slot, "water") .. ".tmp") end
+  if not ok then
+    os.remove(path .. ".tmp")
+    return recordSaveFailure("water", result)
+  end
+  if result ~= true then return recordSaveFailure("water") end
+  return true
 end
 
 -- The terrain and water for (map, slot), as data records, or nil on a
@@ -1037,8 +1192,9 @@ end
 -- { grass = {n=.., buf=..}, flowers = {n=.., buf=..}, figures = {..} } --
 -- produced by ChunkMesher from the Structures quads.
 function MeshCache.saveAux(map, slot, flattened)
-  if not MeshCache.dir() then return end
-  local ok = pcall(function()
+  if not MeshCache.dir() then return false end
+  local path = fileFor(map, slot, "aux")
+  local ok, result = pcall(function()
     local fp = fingerprint(map, slot .. "Aux")
     local body = encodeIndexed(flattened.grass and flattened.grass.n or 0,
                                flattened.grass and flattened.grass.buf,
@@ -1049,10 +1205,14 @@ function MeshCache.saveAux(map, slot, flattened)
                                   flattened.flowers and flattened.flowers.m or 0,
                                   flattened.flowers and flattened.flowers.idx)
     local figures = encodeFigures(flattened.figures or {})
-    writeFile(fileFor(map, slot, "aux"),
-              packPayload(fp, body .. flowers .. figures))
+    return writeFile(path, packPayload(fp, body .. flowers .. figures))
   end)
-  if not ok then os.remove(fileFor(map, slot, "aux") .. ".tmp") end
+  if not ok then
+    os.remove(path .. ".tmp")
+    return recordSaveFailure("aux", result)
+  end
+  if result ~= true then return recordSaveFailure("aux") end
+  return true
 end
 
 -- Load the aux streams: { grass, flowers, figures } data records, or nil.
@@ -1209,6 +1369,13 @@ end
 -- Identity components / diff helpers, exported for boot diagnostics.
 MeshCache.identityParts = identityParts
 MeshCache.identityDiff = identityDiff
+-- Per-session write-failure tracking (F5), for Prebuild's failure message.
+function MeshCache.saveError()
+  return lastSaveError
+end
+function MeshCache.saveFailureCount()
+  return saveFailures
+end
 
 -- Read the build.info sidecar written at build time (nil when absent).
 function MeshCache.readBuildInfo()

--- a/main.lua
+++ b/main.lua
@@ -165,6 +165,20 @@ local function sceneSize(ctx)
 end
 
 local voidFill = { last = nil }
+-- Called after the engine applies a save's options (Game:applyOptions):
+-- the fill that just landed IS the save's declared value, so the change
+-- detector is re-seeded instead of treating the boot/load transition as
+-- a user edit. The game.ready-time cache check runs under the skeleton
+-- save's defaults, and CONTINUE then applies the real slot options -- the
+-- old code read that as a VOID FILL change and invalidated the manifest,
+-- which is why the title gate asked to rebuild on every single launch
+-- even though the cache matched the save exactly (F1). A real change
+-- still invalidates: the OPTIONS row calls setVoidFill directly, never
+-- applyOptions, so check() catches it on the next tick.
+function voidFill.reseed()
+  local TileRenderer = require("src.render.TileRenderer")
+  voidFill.last = TileRenderer.voidFill
+end
 function voidFill.check()
   local TileRenderer = require("src.render.TileRenderer")
   local now = TileRenderer.voidFill
@@ -172,6 +186,18 @@ function voidFill.check()
     ChunkMesher.invalidate()   -- no map id: every ring on every map is stale
   end
   voidFill.last = now
+end
+
+do
+  local Game = require("src.core.Game")
+  if not Game.dramaticShapeApplyOptionsHook then
+    local applyOptions = Game.applyOptions
+    function Game:applyOptions(opts)
+      applyOptions(self, opts)
+      voidFill.reseed()
+    end
+    Game.dramaticShapeApplyOptionsHook = true
+  end
 end
 
 mod.content.render_pipelines:register("voxel", {
@@ -904,8 +930,15 @@ local function showCacheStatus(game)
             or mode == "raw" and "READY (RAW)"
             or "READY"
   end
+  -- which backend created the cache dir: the love.filesystem tree or the
+  -- mkdir shell fallback -- so a support report names the active path
+  local backend = MeshCache.dirBackend()
+  local backendLabel = backend == "love" and "LOVE FS"
+      or backend == "mkdir" and "MKDIR"
+      or "NONE"
   game.stack:push(TextBox.new(game,
-    ("%s\fGEOMETRY %d"):format(label, MeshCache.GEOMETRY_VERSION)))
+    ("%s\fGEOMETRY %d\fDIR: %s"):format(label, MeshCache.GEOMETRY_VERSION,
+                                          backendLabel)))
 end
 
 local function confirmCacheWipe(game)
@@ -1017,45 +1050,52 @@ mod.content.screens:register("PotatoVoxelSettings", {
   end,
 })
 
-local function startTitleAction(game, action)
-  if CachePrebuild.isReady() or not CachePrebuild.available() then
-    action()
-    return
-  end
+-- The cache build gate, moved OFF the title menu (F1). The game.ready-time
+-- readiness check runs under the skeleton save's DEFAULT options, so a
+-- player whose save chose another VOID FILL read as "cache stale" on every
+-- launch even when the cache matched the save exactly. The READY re-check
+-- and the one-time prompt now run AFTER the engine applies the save's own
+-- options: CONTINUE lands here from restoreSave, NEW GAME from
+-- makeTitleState's onNewGame callback. The prompt is a modal over whatever
+-- the save left on top (the overworld, Oak's speech), and an accepted
+-- build runs cooperatively in the background exactly like the
+-- OPTIONS-menu prebuild.
+local function gateCacheBuild(game)
+  CachePrebuild.refresh(game)
+  if CachePrebuild.isReady() or not CachePrebuild.available() then return end
   local TextBox = require("src.render.TextBox")
   game.stack:push(TextBox.new(game, "MAP CACHE\nNOT READY.\fBUILD NOW?", nil, {
     defaultNo = true,
     choice = function(yes)
-      if not yes then
-        action()
-        return
+      if yes and CachePrebuild.start(game) then
+        local Progress = V.require("CachePrebuildScreen")
+        game.stack:push(Progress.new(game))
       end
-      if not CachePrebuild.start(game) then
-        action()
-        return
-      end
-      local Progress = V.require("CachePrebuildScreen")
-      game.stack:push(Progress.new(game, action, function()
-        local title = game.stack:top()
-        if title and title.openMenu then title:openMenu() end
-      end))
     end,
   }))
 end
 
-mod.hooks:wrap("ui.title_menu.items", function(next, game, items)
-  local out = next(game, items)
-  if type(out) ~= "table" then return out end
-  local Strings = require("src.core.Strings")
-  local labels = { [Strings("CONTINUE")] = true, [Strings("NEW GAME")] = true }
-  for _, item in ipairs(out) do
-    if type(item) == "table" and labels[item.label] and item.onSelect then
-      local action = item.onSelect
-      item.onSelect = function() startTitleAction(game, action) end
+do
+  local Game = require("src.core.Game")
+  if not Game.dramaticShapeCacheGateHook then
+    local restoreSave = Game.restoreSave
+    function Game:restoreSave(loaded, recovered)
+      restoreSave(self, loaded, recovered)
+      gateCacheBuild(self)
     end
+    local makeTitleState = Game.makeTitleState
+    function Game:makeTitleState()
+      local title = makeTitleState(self)
+      local onNewGame = title.onNewGame
+      title.onNewGame = function()
+        onNewGame()
+        gateCacheBuild(self)
+      end
+      return title
+    end
+    Game.dramaticShapeCacheGateHook = true
   end
-  return out
-end)
+end
 
 -- The realtime diagnostics panel: when enabled by benchmark instrumentation,
 -- the mod owns a screen-space overlay over the finished frame. render.hud fires once per

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -161,6 +161,92 @@ if ffiOk and cacheDir then
   testLove.data = oldData
   _G.love = oldLove
   MeshCache.wipe({ { id = "A", slot = "body" } })
+
+  -- --- relaunch simulation: same data + options => READY, no rebuild ------
+  local function readManifestIdentity()
+    local f = io.open(cacheDir .. "/cache.info", "rb")
+    if not f then return nil end
+    local line = f:read()
+    f:close()
+    return line and line:match("^PVMC1\t([^\t]+)\t%d+$") or nil
+  end
+  local function readBuildInfoText()
+    local f = io.open(cacheDir .. "/build.info", "rb")
+    if not f then return nil end
+    local text = f:read("*a")
+    f:close()
+    return text
+  end
+
+  os.remove(cacheDir .. "/build.info")
+  local buildJob = { id = "A", slot = "body" }
+  MeshCache.configure({ maps = maps, tilesets = {} })
+  MeshCache.begin()
+  MeshCache.saveTerrain(fakeMap, "body", nil, 0)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  local builtRecord = MeshCache.jobRecord(fakeMap, "body")
+  T.check(MeshCache.writeManifest({ [builtRecord.key] = builtRecord }, 1),
+          "active build writes a manifest")
+  local builtIdentity = readManifestIdentity()
+  T.eq(builtIdentity, MeshCache.identity(),
+       "manifest identity equals the live identity after an unchanged build")
+  local buildInfo = readBuildInfoText()
+  T.check(buildInfo and buildInfo:find("identity=" .. builtIdentity, 1, true),
+          "build.info records the build identity")
+
+  -- A fresh configure() is the relaunch: same maps, same default options.
+  MeshCache.configure({ maps = maps, tilesets = {} })
+  T.eq(MeshCache.identity(), builtIdentity,
+       "relaunch recomputes the same cache identity")
+  T.check(MeshCache.ready({ buildJob }),
+          "relaunch reports READY from the existing manifest (no rebuild)")
+  T.check(MeshCache.getLastFailure() == nil,
+          "a READY cache leaves lastFailure unset")
+
+  -- --- begin()-time snapshot survives a mid-build identity drift ---------
+  local okTR, TileRenderer = pcall(require, "src.render.TileRenderer")
+  if okTR and TileRenderer then
+    local oldVoidFill = TileRenderer.voidFill
+    local driftedFill = oldVoidFill == "cactus" and "trees" or "cactus"
+    os.remove(cacheDir .. "/build.info")
+    MeshCache.configure({ maps = maps, tilesets = {} })
+    MeshCache.begin()
+    local snapshotIdentity = MeshCache.identity()
+    local snapshot = MeshCache.buildInfoSnapshot()
+    T.check(snapshot and snapshot.identity == snapshotIdentity,
+            "buildInfoSnapshot exposes the begin()-time identity")
+    -- Mid-build drift: a live identity component changes after begin().
+    TileRenderer.voidFill = driftedFill
+    MeshCache.saveTerrain(fakeMap, "body", nil, 0)
+    MeshCache.saveWater(fakeMap, "body", nil, 0)
+    MeshCache.saveAux(fakeMap, "body", { figures = {} })
+    T.check(MeshCache.writeManifest({ [builtRecord.key] = builtRecord }, 1),
+            "build finishes normally despite a mid-build identity drift")
+    local driftedManifestId = readManifestIdentity()
+    T.eq(driftedManifestId, snapshotIdentity,
+         "manifest carries the begin()-time identity, not the drifted one")
+    local driftedBuildInfo = readBuildInfoText()
+    T.check(driftedBuildInfo
+              and driftedBuildInfo:find("identity=" .. snapshotIdentity, 1, true),
+            "build.info carries the begin()-time identity")
+    -- Next launch: a fresh session drops the snapshot while the live
+    -- identity still carries the drifted voidFill, so ready() must report
+    -- the mismatch explicitly instead of a generic rejection.
+    MeshCache.configure({ maps = maps, tilesets = {} })
+    T.check(not MeshCache.ready({ buildJob }),
+            "drifted live identity rejects the cache")
+    local failure = MeshCache.getLastFailure()
+    T.check(failure and failure.reason == "identity_mismatch",
+            "rejection is reported as identity_mismatch")
+    T.eq(failure.actual, snapshotIdentity,
+         "identity_mismatch reports the manifest (actual) identity")
+    T.check(failure.diffs and failure.diffs[1] == "voidFill",
+            "identity_mismatch diff pinpoints the voidFill drift")
+    TileRenderer.voidFill = oldVoidFill
+    MeshCache.wipe({ buildJob })
+  end
+
   MeshCache.available = originalAvailable
 end
 

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -85,9 +85,68 @@ T.check(record.terrainFp ~= record.waterFp
           and record.waterFp ~= record.auxFp,
         "job record fingerprints each payload separately")
 
+-- F6: the dataset revision covers every tileset input the mesher reads.
+local function shallowCopy(table_)
+  local out = {}
+  for key, value in pairs(table_ or {}) do out[key] = value end
+  return out
+end
+local baseData = {
+  maps = {
+    A = { id = "A", width = 4, height = 5, borderBlock = 0,
+          tileset = "T", blocks = { 1, 2, 3, 4, 5, 6 },
+          connections = { east = { map = "B", offset = 0 } } },
+  },
+  tilesets = {
+    T = { id = "T", image = "t.png", tilesPerRow = 16,
+          blocks = { 1, 2 }, walkable = { 1, 2 }, counterTiles = {},
+          doorTiles = {}, warpTiles = {}, grassTile = 1 },
+  },
+}
+MeshCache.configure(baseData)
+local baseIdentity = MeshCache.identity()
+local function revisionDiffers(variant)
+  MeshCache.configure(variant)
+  local different = MeshCache.identity() ~= baseIdentity
+  MeshCache.configure(baseData)
+  return different
+end
+local counterVariant = { maps = baseData.maps,
+                         tilesets = { T = shallowCopy(baseData.tilesets.T) } }
+counterVariant.tilesets.T.counterTiles = { 42 }
+T.check(revisionDiffers(counterVariant),
+        "counterTiles changes the dataset revision")
+local grassVariant = { maps = baseData.maps,
+                       tilesets = { T = shallowCopy(baseData.tilesets.T) } }
+grassVariant.tilesets.T.grassTile = 7
+T.check(revisionDiffers(grassVariant),
+        "grassTile changes the dataset revision")
+local doorVariant = { maps = baseData.maps,
+                      tilesets = { T = shallowCopy(baseData.tilesets.T) } }
+doorVariant.tilesets.T.doorTiles = { 9 }
+T.check(revisionDiffers(doorVariant),
+        "doorTiles changes the dataset revision")
+local warpVariant = { maps = baseData.maps,
+                      tilesets = { T = shallowCopy(baseData.tilesets.T) } }
+warpVariant.tilesets.T.warpTiles = { 4, 5 }
+T.check(revisionDiffers(warpVariant),
+        "warpTiles changes the dataset revision")
+local walkVariant = { maps = baseData.maps,
+                      tilesets = { T = shallowCopy(baseData.tilesets.T) } }
+walkVariant.tilesets.T.walkable = { 1 }
+T.check(revisionDiffers(walkVariant),
+        "walkable changes the dataset revision")
+
 local ffiOk, ffi = pcall(require, "ffi")
 local cacheDir = MeshCache.dir()
 if ffiOk and cacheDir then
+  T.check(MeshCache.dirBackend() == "love"
+            or MeshCache.dirBackend() == "mkdir",
+          "dir resolution records which backend created the folder")
+  T.check(MeshCache.probeWritable(cacheDir),
+          "the resolved cache dir passes a real io write probe")
+  T.check(not MeshCache.probeWritable("/definitely/not/here/potato_voxel"),
+          "a nonexistent directory fails the write probe")
   local fakeMap = {
     id = "A", tileset = { image = "tileset.png", trueColor = false },
     renderer = { gbcAtlas = false },
@@ -245,6 +304,99 @@ if ffiOk and cacheDir then
             "identity_mismatch diff pinpoints the voidFill drift")
     TileRenderer.voidFill = oldVoidFill
     MeshCache.wipe({ buildJob })
+  end
+
+  -- --- F3 + F5: saves report results; begin() keeps the manifest ---------
+  MeshCache.configure({ maps = maps, tilesets = {} })
+  MeshCache.begin()
+  T.eq(MeshCache.saveTerrain(fakeMap, "body", nil, 0), true,
+       "saveTerrain reports its write result")
+  T.eq(MeshCache.saveWater(fakeMap, "body", nil, 0), true,
+       "saveWater reports its write result")
+  T.eq(MeshCache.saveAux(fakeMap, "body", { figures = {} }), true,
+       "saveAux reports its write result")
+  T.eq(MeshCache.saveError(), nil,
+       "successful saves leave no write error")
+  local f3Record = MeshCache.jobRecord(fakeMap, "body")
+  T.check(MeshCache.writeManifest({ [f3Record.key] = f3Record }, 1),
+          "build writes a manifest")
+  T.check(exists(cacheDir .. "/cache.info"),
+          "manifest exists after the build")
+  MeshCache.begin()
+  T.check(exists(cacheDir .. "/cache.info"),
+          "begin() keeps the manifest (F3): a mid-build death leaves it")
+  T.check(MeshCache.writeManifest({ [f3Record.key] = f3Record }, 1),
+          "manifest rewrite over an existing file succeeds (F4 self-heal)")
+  MeshCache.wipe({ buildJob })
+
+  -- --- F3: an interrupted build leaves a manifest naming finished jobs --
+  local jobSet = Prebuild.enumerate(maps)   -- A body/full, B body/full
+  local fakeMapB = {
+    id = "B", tileset = { image = "tileset.png", trueColor = false },
+    renderer = { gbcAtlas = false },
+  }
+  MeshCache.configure({ maps = maps, tilesets = {} })
+  MeshCache.begin()
+  MeshCache.saveTerrain(fakeMap, "body", nil, 0)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  local partial = {}
+  local bodyRecord = MeshCache.jobRecord(fakeMap, "body")
+  partial[bodyRecord.key] = bodyRecord
+  T.check(MeshCache.writeProgress(partial, #jobSet),
+          "writeProgress writes a partial manifest")
+  T.check(exists(cacheDir .. "/cache.info"),
+          "interrupted build leaves a manifest behind")
+  -- the relaunch: a fresh session rescans the actual files
+  MeshCache.configure({ maps = maps, tilesets = {} })
+  local complete, doneCount = MeshCache.scanComplete(jobSet)
+  T.eq(doneCount, 1, "scanComplete finds exactly the one finished job")
+  T.check(complete["A/body"] ~= nil and complete["A/full"] == nil
+          and complete["B/body"] == nil,
+          "scanComplete names the finished job and skips the rest")
+  local readyOk, resumeCount = MeshCache.ready(jobSet)
+  T.check(not readyOk, "a partial build is not READY")
+  T.eq(resumeCount, 1, "ready reports the resumable job count")
+  MeshCache.wipe(jobSet)
+
+  -- --- F1: boot under skeleton options, refresh after the save loads ----
+  local okTR, TileRenderer = pcall(require, "src.render.TileRenderer")
+  if okTR and TileRenderer then
+    local originalFill = TileRenderer.voidFill
+    local saveFill = originalFill ~= "cactus" and "cactus" or "water"
+    MeshCache.configure({ maps = maps, tilesets = {} })
+    TileRenderer.voidFill = saveFill
+    MeshCache.begin()
+    for _, job in ipairs(jobSet) do
+      local m = job.id == "A" and fakeMap or fakeMapB
+      MeshCache.saveTerrain(m, job.slot, nil, 0)
+      MeshCache.saveWater(m, job.slot, nil, 0)
+      MeshCache.saveAux(m, job.slot, { figures = {} })
+    end
+    local full = {}
+    for _, job in ipairs(jobSet) do
+      local m = job.id == "A" and fakeMap or fakeMapB
+      local rec = MeshCache.jobRecord(m, job.slot)
+      full[rec.key] = rec
+    end
+    T.check(MeshCache.writeManifest(full, #jobSet),
+            "build completes under the save's VOID FILL")
+    -- boot: game.ready runs under the skeleton save's DEFAULT options
+    TileRenderer.voidFill = originalFill
+    local stubGame = { data = { maps = maps, tilesets = {} } }
+    T.check(not Prebuild.bootstrap(stubGame),
+            "skeleton defaults do not match the save's cache")
+    T.check(not Prebuild.isReady(),
+            "cache not READY while the skeleton options are active")
+    -- the save loads and the engine applies the slot's real options; the
+    -- post-load gate refreshes under them (no invalidation needed)
+    TileRenderer.voidFill = saveFill
+    T.check(Prebuild.refresh(stubGame),
+            "refresh after the save's options land reports READY")
+    T.check(Prebuild.isReady(),
+            "no rebuild prompt after the boot/load options transition")
+    TileRenderer.voidFill = originalFill
+    MeshCache.wipe(jobSet)
   end
 
   MeshCache.available = originalAvailable


### PR DESCRIPTION
## What's in 1.4.2

- **No more "rebuild every launch":** the cache READY check ran with default settings before the save loaded, so saves with a non-default VOID FILL read as stale on every launch. The check now runs after the save (and its options) load; the BUILD NOW? prompt appears over the world instead of the title screen.
- **Interrupted builds resume:** a build cut short no longer deletes its progress record; the next launch continues from the finished jobs instead of prompting forever.
- **Windows:** cache-info rewrites over an existing file no longer fail silently (rename retry).
- **Better errors:** build failures name the real reason (full SD card, read-only folder).
- **Sturdier cache folder:** love.filesystem first, mkdir fallback, real write probe, retry on failure; CACHE STATUS shows the active backend.
- **Boot diagnostics:** build.info sidecar + exact rejection reasons in the log.

One-time cache refresh on update (the cache now records more of your game data).

Tests: 75/75 cache, 90/90 mod, loading tests, lint + validate pass.