### PR TITLE
1.4.3: fix black screen with shadows on Mediatek/Mali devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.4.3] - 2026-08-12
+
+### Fixed
+
+- Black screen with shadows enabled on Mediatek/Mali Android devices. Two
+  failure paths are closed: a shadow pass that dies mid-draw can no longer
+  leave its offscreen canvas bound (the world was rendering into the shadow
+  map, which is the black frame), and NaN values from a degenerate light
+  fit can no longer poison the shadow math (NaN comparisons silently pass
+  GLSL bounds checks, then black out every fragment they touch). Both now
+  fall back to a flat-lit frame for that moment instead of a black screen.
+
 ## [1.4.2] - 2026-08-12
 
 ### Fixed

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -164,7 +164,12 @@ local SHADER = [[
     vec4 c = lightVP * (model * vertex_position);
     // the projection is orthographic, so w is 1 and clip z IS the depth,
     // linear in world units along the sun line
-    vDepth = c.z * 0.5 + 0.5;
+    // A degenerate fit can put NaN into the matrix. NaN compares false in
+    // GLSL, so it would sail through every downstream guard and poison the
+    // packed map -- a depth of NaN reads as "everything is shadowed" on
+    // Mali-family GPUs, which is a black screen. Store the far depth
+    // (cast nothing) instead.
+    vDepth = (c.z == c.z) ? (c.z * 0.5 + 0.5) : 1.0;
     return c;
   }
 #endif
@@ -465,6 +470,15 @@ function ShadowMap.fitKey(cx, cy, vw, vh)
   return math.floor(l / tx), math.floor(b / ty)
 end
 
+-- Whether a fitted box can be projected at all. Exported so the suite can
+-- probe the exact guard: zero, negative or NaN extents (a camera mid-tween,
+-- a half-initialised view) would otherwise write inf/NaN into clipVP and
+-- uvVP, and every fragment the main pass looked up would read a poisoned
+-- depth -- the black-screen-on-Mediatek report.
+function ShadowMap._degenerate(w, h, near, far)
+  return not (w > 0 and h > 0 and far > near)
+end
+
 local function fit(cx, cy, vw, vh)
   local l, r, b, t, zn, zf, view = boxCorners(cx, cy, vw, vh)
 
@@ -486,6 +500,11 @@ local function fit(cx, cy, vw, vh)
   -- and the slack keeps geometry taller than HEIGHT from being clipped
   -- clean out of the pass instead of merely casting a truncated shadow
   local near, far = -zf - 64, -zn + 64
+  -- A degenerate frustum (NaN or non-positive extents) must NOT update the
+  -- matrices the main pass reads: the previous fit stays live, the caller
+  -- skips the pass, and the frame renders flat-lit instead of poisoned.
+  -- NaN compares false, so the plain > tests above reject it too.
+  if ShadowMap._degenerate(w, h, near, far) then return false end
   local proj = Mat4.ortho(l, r, b, t, near, far)
   -- flip clip-space Y for the same reason the camera does: we bypass
   -- LOVE's transform_projection, and canvas coordinates run Y DOWN, so
@@ -505,6 +524,7 @@ local function fit(cx, cy, vw, vh)
   -- the stored depth spans the frustum, so a world-pixel bias is that
   -- fraction of it
   ShadowMap.bias = ShadowMap.slack / math.max(1, far - near)
+  return true
 end
 
 -- How much of the compare's forgiveness a snugged caster takes back, 0..1.
@@ -584,7 +604,7 @@ function ShadowMap.begin(cx, cy, vw, vh, sprites)
     -- The canvas is then (re)made at that edge -- the rung's whole point is
     -- how many texels the box is divided into, so a 1536 fit on a 1024
     -- canvas would be a 1024 map wearing a 1536 fit's snap and bias.
-    fit(cx, cy, vw, vh)
+    if not fit(cx, cy, vw, vh) then return false end
     if getCanvas(ShadowMap.res) == nil then return false end
   end
   local c = sprites and spriteCanvas or canvas
@@ -670,6 +690,22 @@ function ShadowMap.finish(sig, sprites)
     lastSig = sig
     ready = true
   end
+end
+
+-- Unconditionally restore the GL state a pass changes, after an error
+-- anywhere inside begin..finish. A pass that dies mid-draw leaves the
+-- shadow canvas bound, and every later frame renders the WORLD into that
+-- 1024px offscreen map -- a black screen, exactly the Mediatek report.
+-- Callers pcall-wrap their pass and call this from the error handler;
+-- harmless (and cheap) when no pass is open.
+function ShadowMap.abort()
+  drawing, drawingSprites = false, false
+  ready, spritesReady = false, false
+  pcall(love.graphics.setShader)
+  pcall(love.graphics.setDepthMode)
+  pcall(love.graphics.setCanvas)
+  pcall(love.graphics.setBlendMode, prevBlend or "alpha", prevAlphaMode)
+  pcall(love.graphics.setColor, 1, 1, 1, 1)
 end
 
 -- Drop the GPU objects (window resize, hot reload).

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -178,6 +178,11 @@ local SHADER = [[
   // while letting the sprite layer redraw alone when a character idles.
   float sunlight(vec3 p) {
     if (sunDark <= 0.0) return 1.0;
+    // NaN out of a degenerate fit: GLSL comparisons are false for NaN, so
+    // the frustum checks below would let it through and the multiply after
+    // would black the fragment out. Mali-family GPUs surface exactly this
+    // as the reported black screen; a NaN lookup casts no shadow instead.
+    if (p.x != p.x || p.y != p.y || p.z != p.z) return 1.0;
     // outside the sun's frustum nothing was recorded, so nothing occludes
     if (p.x < 0.0 || p.x > 1.0 || p.y < 0.0 || p.y > 1.0 || p.z > 1.0) {
       return 1.0;

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -865,90 +865,104 @@ local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
   if not worldStale and not spriteStale then return end
 
   if worldStale then
-    if not ShadowMap.begin(cx, cy, vw, vh, false) then return end
-    ShadowMap.draw(terrain, atlasFor(state.map), nil)
-    for i, nb in ipairs(state.neighbors or {}) do
-      ShadowMap.draw(nbMesh[i], atlasFor(nb.map),
-                     Mat4.translate(nb.ox, 0, nb.oy))
-    end
-    -- The water surface, which the terrain mesh no longer carries (it is its
-    -- own reflective pass now -- see Water). The sun still has to see it, or
-    -- the map the light records has a hole at every lake and the frustum's
-    -- far plane answers for the surface a shoreline tree's shadow falls on.
-    ShadowMap.draw(water, atlasFor(state.map), nil)
-    for i, nb in ipairs(state.neighbors or {}) do
-      ShadowMap.draw(nbWater and nbWater[i], atlasFor(nb.map),
-                     Mat4.translate(nb.ox, 0, nb.oy))
-    end
-    -- flower billboards live outside the terrain mesh (they draw after the
-    -- characters, pulled -- see render), but the sun still sees them: a
-    -- handful of cutouts per meadow, unlike the grass left out below.
-    -- Every thin card from here down is SNUGGED toward the sun along its own
-    -- ray (ShadowMap.snug) so its shadow keeps contact with its feet instead
-    -- of starting a bias-width away.
-    ShadowMap.draw(ChunkMesher.flowers(state.map), atlasFor(state.map),
-                   ShadowMap.snug(nil))
-    for _, nb in ipairs(state.neighbors or {}) do
-      ShadowMap.draw(ChunkMesher.flowers(nb.map), atlasFor(nb.map),
-                     ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
-    end
-    -- From here down it is the CAST, marked as such in the map (see
-    -- ShadowMap.sprites) so water can decline them: everything the world casts
-    -- still shades a lake, a silhouette of somebody standing beside it does
-    -- not. Ground, roofs and the characters themselves take them as before.
-    ShadowMap.sprites(true)
-    -- authored figures cast too, for the same reason the flowers do: a
-    -- handful of cards per map, and a person with no shadow reads as pasted on
-    eachFigure(state.map, 0, 0, function(mesh, _, caster)
-      ShadowMap.draw(mesh, atlasFor(state.map), ShadowMap.snug(caster))
-    end)
-    for _, nb in ipairs(state.neighbors or {}) do
-      eachFigure(nb.map, nb.ox, nb.oy, function(mesh, _, caster)
-        ShadowMap.draw(mesh, atlasFor(nb.map), ShadowMap.snug(caster))
-      end)
-    end
-    -- the STADIUM models: geometry, not cut-outs (see BattleScene.castShadows
-    -- for why they are un-snugged and outside the sprite flag)
-    pcall(function()
-      local stageArena, stageY = V.require("OverworldBattle").stage()
-      if stageArena and stageArena.discs then
-        V.require("StadiumStage").cast(ShadowMap, stageArena, stageY or 0)
+    -- the whole pass is pcall-wrapped: a throw between begin and finish
+    -- (a mesh released mid-map-change, a driver hiccup) used to leave the
+    -- shadow canvas bound, and the main pass then rendered the world into
+    -- the offscreen map -- the black-screen report. abort() unbinds it, so
+    -- the frame falls back to flat-lit instead of black.
+    local ok, err = pcall(function()
+      if not ShadowMap.begin(cx, cy, vw, vh, false) then return end
+      ShadowMap.draw(terrain, atlasFor(state.map), nil)
+      for i, nb in ipairs(state.neighbors or {}) do
+        ShadowMap.draw(nbMesh[i], atlasFor(nb.map),
+                       Mat4.translate(nb.ox, 0, nb.oy))
       end
-      V.require("Stadium").cast(ShadowMap)
+      -- The water surface, which the terrain mesh no longer carries (it is its
+      -- own reflective pass now -- see Water). The sun still has to see it, or
+      -- the map the light records has a hole at every lake and the frustum's
+      -- far plane answers for the surface a shoreline tree's shadow falls on.
+      ShadowMap.draw(water, atlasFor(state.map), nil)
+      for i, nb in ipairs(state.neighbors or {}) do
+        ShadowMap.draw(nbWater and nbWater[i], atlasFor(nb.map),
+                       Mat4.translate(nb.ox, 0, nb.oy))
+      end
+      -- flower billboards live outside the terrain mesh (they draw after the
+      -- characters, pulled -- see render), but the sun still sees them: a
+      -- handful of cutouts per meadow, unlike the grass left out below.
+      -- Every thin card from here down is SNUGGED toward the sun along its own
+      -- ray (ShadowMap.snug) so its shadow keeps contact with its feet instead
+      -- of starting a bias-width away.
+      ShadowMap.draw(ChunkMesher.flowers(state.map), atlasFor(state.map),
+                     ShadowMap.snug(nil))
+      for _, nb in ipairs(state.neighbors or {}) do
+        ShadowMap.draw(ChunkMesher.flowers(nb.map), atlasFor(nb.map),
+                       ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
+      end
+      -- From here down it is the CAST, marked as such in the map (see
+      -- ShadowMap.sprites) so water can decline them: everything the world casts
+      -- still shades a lake, a silhouette of somebody standing beside it does
+      -- not. Ground, roofs and the characters themselves take them as before.
+      ShadowMap.sprites(true)
+      -- authored figures cast too, for the same reason the flowers do: a
+      -- handful of cards per map, and a person with no shadow reads as pasted on
+      eachFigure(state.map, 0, 0, function(mesh, _, caster)
+        ShadowMap.draw(mesh, atlasFor(state.map), ShadowMap.snug(caster))
+      end)
+      for _, nb in ipairs(state.neighbors or {}) do
+        eachFigure(nb.map, nb.ox, nb.oy, function(mesh, _, caster)
+          ShadowMap.draw(mesh, atlasFor(nb.map), ShadowMap.snug(caster))
+        end)
+      end
+      -- the STADIUM models: geometry, not cut-outs (see BattleScene.castShadows
+      -- for why they are un-snugged and outside the sprite flag)
+      pcall(function()
+        local stageArena, stageY = V.require("OverworldBattle").stage()
+        if stageArena and stageArena.discs then
+          V.require("StadiumStage").cast(ShadowMap, stageArena, stageY or 0)
+        end
+        V.require("Stadium").cast(ShadowMap)
+      end)
+      ShadowMap.sprites(false)
+      ShadowMap.finish(worldSig, false)
     end)
-    ShadowMap.sprites(false)
-    ShadowMap.finish(worldSig, false)
+    if not ok then
+      ShadowMap.abort()
+      pcall(print, "[PotatoVoxel] shadow world pass aborted: " .. tostring(err))
+    end
   end
 
   -- sprite layer: posed characters + battle cards, snugged and marked as
   -- the cast so water declines them. Only when a sprite actually moved.
   if spriteLayer and (spriteStale or worldStale) then
-    if not ShadowMap.begin(cx, cy, vw, vh, true) then return end
-    ShadowMap.sprites(true)
-    for _, p in ipairs(posed) do
-      local def = p.sprite.def
-      -- viewFacing, exactly as the camera draw picks it (see viewFacing for
-      -- why the two passes must agree): in first person the sun's card
-      -- swaps frame as the eye circles, which costs a redraw the signature
-      -- already charges for (FirstPerson.signature) and keeps a card from
-      -- fringing against a mirror-flipped record of itself
-      local frame, mirror = frameFor(def, viewFacing(p), p.phase, p.flip)
-      local mesh = SpriteBillboards.shadowQuad(def, frame)
-      if mesh then
-        ShadowMap.draw(mesh, p.sprite:resolveImage(),
-                       ShadowMap.snug(
-                         Voxel3D.casterMatrix(p.px, p.py, p.gh + (p.lift or 0),
-                                              mirror)))
+    local ok = pcall(function()
+      if not ShadowMap.begin(cx, cy, vw, vh, true) then return end
+      ShadowMap.sprites(true)
+      for _, p in ipairs(posed) do
+        local def = p.sprite.def
+        -- viewFacing, exactly as the camera draw picks it (see viewFacing for
+        -- why the two passes must agree): in first person the sun's card
+        -- swaps frame as the eye circles, which costs a redraw the signature
+        -- already charges for (FirstPerson.signature) and keeps a card from
+        -- fringing against a mirror-flipped record of itself
+        local frame, mirror = frameFor(def, viewFacing(p), p.phase, p.flip)
+        local mesh = SpriteBillboards.shadowQuad(def, frame)
+        if mesh then
+          ShadowMap.draw(mesh, p.sprite:resolveImage(),
+                         ShadowMap.snug(
+                           Voxel3D.casterMatrix(p.px, p.py, p.gh + (p.lift or 0),
+                                                mirror)))
+        end
       end
-    end
-    -- a staged fight's mons (VR frames only): the same cards the eye pass
-    -- stands on the arena, snugged like every thin card, marked as the cast
-    -- so the water can decline them like everybody else's silhouette
-    for _, card in ipairs(battleCards or {}) do
-      ShadowMap.draw(BattleBillboard.mesh(), card.tex, ShadowMap.snug(card.model))
-    end
-    ShadowMap.sprites(false)
-    ShadowMap.finish(spriteSig, true)
+      -- a staged fight's mons (VR frames only): the same cards the eye pass
+      -- stands on the arena, snugged like every thin card, marked as the cast
+      -- so the water can decline them like everybody else's silhouette
+      for _, card in ipairs(battleCards or {}) do
+        ShadowMap.draw(BattleBillboard.mesh(), card.tex, ShadowMap.snug(card.model))
+      end
+      ShadowMap.sprites(false)
+      ShadowMap.finish(spriteSig, true)
+    end)
+    if not ok then ShadowMap.abort() end
   end
 end
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -85,6 +85,18 @@ if brick then
   ShadowSettings.enabledSetting.labels = el
   ShadowSettings.enabledSetting.index = nil
   T.check(ShadowSettings.enabled(), "SHADOWS ON re-enables the pass")
+  -- degenerate-fit guard: zero, negative or NaN extents must not write
+  -- inf/NaN into the matrices the main pass samples (black-screen class)
+  T.check(ShadowMap._degenerate(0, 100, -10, 10), "zero width is degenerate")
+  T.check(ShadowMap._degenerate(100, 0, -10, 10), "zero height is degenerate")
+  T.check(ShadowMap._degenerate(100, 100, 10, 10), "zero depth span is degenerate")
+  T.check(ShadowMap._degenerate(100, 100, 10, -10), "inverted depth is degenerate")
+  T.check(ShadowMap._degenerate(0 / 0, 100, -10, 10), "NaN width is degenerate")
+  T.check(not ShadowMap._degenerate(100, 100, -100, 100),
+          "a sane frustum is not degenerate")
+  T.check(ShadowMap._source():find("c.z == c.z", 1, true),
+          "shadow shader stores far depth instead of NaN")
+  T.check(ShadowMap.abort ~= nil, "abort() exists for pcall error handlers")
   T.eq(Water.setting.values[1], "off", "WATER defaults off")
   T.eq(#Water.setting.values, 3, "WATER ladder stays available")
   T.eq(ForestAtmos.setting.values[1], "off", "FOREST FX defaults off")


### PR DESCRIPTION
Users on Mediatek (Mali GPU) devices report a black screen until SHADOWS is turned off (issue #19: Moto g power 5G 2024, Dimensity 7020).

Two failure paths closed:

1. **Canvas leak:** a shadow pass that died mid-draw (mesh evicted on map change, driver hiccup) left the shadow canvas bound — every later frame rendered the world into the offscreen map. Both cast passes in `VoxelScene.castShadows` are now pcall-wrapped and call `ShadowMap.abort()` on error (unbinds canvas/shader/depth/blend), so the frame falls back to flat-lit.
2. **NaN poisoning:** a degenerate light fit wrote inf/NaN into the shadow matrices. GLSL NaN comparisons are false, so the frustum bounds checks pass NaN through and the shade multiply blacks the fragment. Fixed with a degenerate-fit guard in `fit()` (previous fit stays live), a NaN guard in the shadow vertex shader (stores far depth), and a NaN guard in `sunlight()` (NaN lookup casts no shadow).

Tests: +8 checks (degenerate-fit guard, shader NaN guard) — 98/98 mod, 75/75 cache, lint + validate pass.