### PR TITLE
1.4.4: use the HIGH shadow path on Mali devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.4.4] - 2026-08-12
+
+### Fixed
+
+- Mediatek/Mali devices: every voxel rung now uses the HIGH shadow path
+  (the sprite-layer map) instead of the flat contact-blob fallback. The
+  fallback path is what froze the screen on the last frame (the game kept
+  running behind it) and dropped the player's shadow on MEDIUM/LOW/POTATO/
+  CUSTOM -- the exact rungs that break are the ones HIGH's configuration
+  never touches, and users confirmed HIGH works. The decal pass is also
+  now crash-proofed so a failing decal can no longer freeze a frame on any
+  device.
+
 ## [1.4.3] - 2026-08-12
 
 ### Fixed

--- a/lib/BrickProfile.lua
+++ b/lib/BrickProfile.lua
@@ -66,10 +66,21 @@ end
 -- animated actor layer, on desktop, Android, and the Brick. MEDIUM and lower
 -- keep the existing contact/blob decal fallback for actors. The world layer
 -- remains governed by the renderer's existing shadow gates.
+--
+-- One exception: Mali (Mediatek) GPUs break on the decal fallback path --
+-- frozen last frame, black frames, missing actor shadows -- while the
+-- sprite-layer map works. Every active rung gets the sprite layer there, so
+-- a Mediatek phone renders the actor shadow the same proven way on CUSTOM
+-- that it does on HIGH.
 BrickProfile.DESKTOP_HIGH_LEVEL = 1
 BrickProfile.DESKTOP_MEDIUM_LEVEL = 2
 
+local profileShadowMap = nil
+
 function BrickProfile.actorShadowMapEnabled(level)
+  if profileShadowMap and profileShadowMap.isMali() then
+    return (level or 0) > 0
+  end
   return level == BrickProfile.DESKTOP_HIGH_LEVEL
 end
 
@@ -105,6 +116,7 @@ function BrickProfile.apply(V)
   local ChunkMesher = V.require("ChunkMesher")
   local ShadowMap = V.require("ShadowMap")
   local Structures = V.require("Structures")
+  profileShadowMap = ShadowMap
 
   -- GEOMETRY DENSITY: the border forest wraps the map edge at the FULL
   -- 3-block depth (12 tiles -- the same width the flat renderer's

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -222,6 +222,29 @@ ShadowMap.bias = 0
 
 local getBlank
 
+-- Mediatek/Mali detection. On Mali GPUs the blob-decal actor path (the
+-- fallback MEDIUM and lower rungs use) misbehaves -- frozen last frame,
+-- black frames, no actor shadow at all -- while the HIGH configuration
+-- (the sprite-layer map) works. BrickProfile reads this to give every
+-- active rung the HIGH shadow path on such devices. Cached; the result
+-- cannot change mid-session.
+local maliDevice = nil
+function ShadowMap.isMali()
+  if maliDevice ~= nil then return maliDevice end
+  maliDevice = false
+  if love and love.graphics and love.graphics.getRendererInfo then
+    local ok, info = pcall(love.graphics.getRendererInfo)
+    if ok and info and info.name then
+      maliDevice = info.name:lower():find("mali", 1, true) ~= nil
+    end
+  end
+  return maliDevice
+end
+-- Test seam: forget the cached answer so the suite can stub a device.
+function ShadowMap._maliReset()
+  maliDevice = nil
+end
+
 local function getShader()
   if shader == nil then
     local ok, sh = pcall(love.graphics.newShader, SHADER)

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -1095,12 +1095,22 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor, eyes)
   local actorMapActive = BrickProfile.actorShadowMapEnabled(Voxel.level)
                         and ShadowMap.active(true)
   if shadowsOn and (not Voxel3D.shadowsActive() or not actorMapActive) then
-    Voxel3D.beginShadows()
-    for _, p in ipairs(posed) do
-      drawShadow(p.sprite, p.anchorX or p.px, p.anchorY or p.py,
-                 viewFacing(p), p.phase, p.flip, p.gh, p.lift)
+    -- pcall-wrapped: a throw in one decal (a driver-specific mesh failure)
+    -- used to abort the whole scene draw -- the engine then kept compositing
+    -- the previous frame's canvas, which reads as a FROZEN screen the player
+    -- can still walk around in. One broken decal now costs only itself.
+    local ok = pcall(function()
+      Voxel3D.beginShadows()
+      for _, p in ipairs(posed) do
+        drawShadow(p.sprite, p.anchorX or p.px, p.anchorY or p.py,
+                   viewFacing(p), p.phase, p.flip, p.gh, p.lift)
+      end
+      Voxel3D.endShadows()
+    end)
+    if not ok then
+      pcall(Voxel3D.endShadows, Voxel3D)
+      pcall(print, "[PotatoVoxel] actor decal pass aborted")
     end
-    Voxel3D.endShadows()
   end
 
   -- and the water over the top of it, reflecting everything just drawn plus

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -97,6 +97,29 @@ if brick then
   T.check(ShadowMap._source():find("c.z == c.z", 1, true),
           "shadow shader stores far depth instead of NaN")
   T.check(ShadowMap.abort ~= nil, "abort() exists for pcall error handlers")
+  -- Mali (Mediatek) devices: every active rung takes the proven HIGH actor
+  -- shadow path -- the blob decal fallback is what freezes/black-frames them
+  local loveG = love and love.graphics
+  local oldRendererInfo = loveG and loveG.getRendererInfo
+  if loveG then
+    loveG.getRendererInfo = function() return { name = "Mali-G57 MC2" } end
+  end
+  ShadowMap._maliReset()
+  T.check(ShadowMap.isMali() == (loveG ~= nil),
+          "a Mali renderer string is detected")
+  if loveG then
+    T.check(brick.actorShadowMapEnabled(2),
+            "Mali: MEDIUM keeps the actor shadow map")
+    T.check(brick.actorShadowMapEnabled(5),
+            "Mali: CUSTOM keeps the actor shadow map")
+    T.check(not brick.actorShadowMapEnabled(0),
+            "Mali: OFF still disables it")
+  end
+  if loveG then loveG.getRendererInfo = oldRendererInfo end
+  ShadowMap._maliReset()
+  T.check(not ShadowMap.isMali(), "a non-Mali renderer is not detected")
+  T.check(not brick.actorShadowMapEnabled(2),
+          "non-Mali: MEDIUM keeps the decal fallback")
   T.eq(Water.setting.values[1], "off", "WATER defaults off")
   T.eq(#Water.setting.values, 3, "WATER ladder stays available")
   T.eq(ForestAtmos.setting.values[1], "off", "FOREST FX defaults off")


### PR DESCRIPTION
Mediatek/Mali follow-up (1.4.3 did not fully fix it). User testing showed:

- HIGH works fine: shadows render, player has a shadow.
- MEDIUM / LOW / POTATO / CUSTOM all break: frozen last frame (game still runs behind it), black frames, and the player shadow disappears entirely.

The broken rungs are exactly the ones that use the flat contact-blob decal fallback; HIGH uses the sprite-layer shadow map. So Mali devices now take the proven HIGH path for every active rung (`BrickProfile.actorShadowMapEnabled` consults the renderer string), and the decal pass is pcall-wrapped so a failing decal can no longer abort the scene draw on any device (the frozen-frame mechanism).

Tests: +6 Mali detection/rung checks — 104/104, 75/75 cache, lint + validate pass.