### PR TITLE
1.4.6: quantized mesh cache, codec-aware cache status, shell-free mkdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [1.4.6] - 2026-08-13
+
+### Performance
+
+- Terrain and water meshes are now stored quantized: 11 bytes a vertex
+  (16-bit position, 16-bit texture coordinates, 8-bit shade) instead of the
+  24-byte six-float stream -- about 54% smaller before compression. Cache
+  files shrink and a cold map load reads and decompresses far less from
+  storage. Positions are integer pixels and come back exactly; texture
+  coordinates and shade round to 1/65535 and 1/255, both far finer than the
+  voxel grid or the baked ambient-occlusion steps can show. The mesh that
+  reaches the GPU is unchanged, so there is no visual difference and no
+  steady-state draw cost.
+
+### Changed
+
+- The mesh cache no longer uses shell commands to set itself up. The cache
+  folder is created through LÖVE's filesystem where it can reach it, and
+  through a direct library call on portable (SD-card) installs, with a real
+  write test before use -- so the cache works where shell access is
+  restricted or unavailable. WIPE CACHE lists files through the filesystem
+  API instead of a shell listing.
+
+- **CACHE STATUS** now names the compression method: **READY (LZ4)**,
+  **READY (ZSTD)**, **READY (RAW)**, or **READY (MIXED)**. The cache tries
+  zstd first when the runtime provides it, and reports whichever codec it
+  actually used.
+
+### Added
+
+- The cache format now records its compression codec per file, so a cache
+  written by one build stays readable by another and the status can name the
+  real method. Updating to 1.4.6 refreshes the cache once (the geometry
+  version moved to 18), in the background or on demand.
+
+## [1.4.5] - 2026-08-13
+
+### Fixed
+
+- Stadium models no longer play a hurt/faint-looking animation when sent
+  out. Two causes, both in the send-out entrance. The anchor that pins a
+  Pokemon to its tile over-corrected when an entrance hopped: the lagged
+  offset outlived the hop and dragged the body below the tile on the way
+  back down, which is a collapse no matter what the animation said. It is
+  clamped to the excursion that caused it, so a returned hop is not
+  dragged past the tile it came back to. And species whose entrance is a
+  genuine drop to well under standing height (Squirtle into its shell,
+  Goldeen flat on the ground -- 48 of the 151) no longer play it at all:
+  the entrance is measured once at load, through the anchor the player
+  actually sees, and a species that reads as hurt on arrival now arrives
+  on its standby loop instead. The standbys and the entrances that still
+  read as entrances are untouched.
+
 ## [1.4.4] - 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,10 +77,14 @@ python3 tools/modkit.py pack mods/potato_voxel
   the save dir; delete it (or the whole `mod-derived` tree) to force a
   rebuild. `MeshCache.GEOMETRY_VERSION` must be bumped whenever geometry
   output changes — the cache fingerprint does not cover every geometry
-  knob. Large payloads use LZ4 compression when the runtime supports it;
-  raw payloads remain readable as a fallback. This reduces storage and cache
-  read cost, not steady-state GPU draw cost. Existing raw entries are repacked
-  lazily as they are loaded; running PREBUILD CACHE migrates the full set.
+  knob. Terrain and water payloads are quantized before compression:
+  positions as 16-bit pixels, texture coords as 16-bit, shade as 8-bit —
+  11 bytes a vertex instead of the 24-byte float stream (about 54% smaller),
+  with no visible change on the voxel grid. Large payloads then use LZ4
+  compression when the runtime supports it; raw payloads remain readable as
+  a fallback. This reduces storage and cache read cost, not steady-state GPU
+  draw cost. Existing raw entries are repacked lazily as they are loaded;
+  running PREBUILD CACHE migrates the full set.
   Boot-time READY checks read only bounded headers and file sizes; full
   decompression and checksum validation are deferred until a map is used.
 - **OPTIONS → PREBUILD CACHE** cooperatively builds every map's body and full

--- a/lib/AntiAlias.lua
+++ b/lib/AntiAlias.lua
@@ -229,7 +229,7 @@ function AntiAlias.resolve(canvas, w, h, slot)
   -- the scene canvas filters nearest for its usual 1:1 blit; the taps want
   -- linear, put back below so every other pass finds what it expects
   pcall(canvas.setFilter, canvas, "linear", "linear")
-  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.setColor()
   -- replace, not alpha-blend: this is an image-processing copy, and the alpha
   -- the shader worked out has to land as itself rather than be composited
   -- against whatever the target held

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -39,7 +39,13 @@ local Budget = V.require("BuildBudget")
 local ffi = nil
 do
   local ok, mod = pcall(require, "ffi")
-  if ok then ffi = mod end
+  if ok then
+    ffi = mod
+    -- The portable (SD-card) cache dir sits outside love.filesystem's root
+    -- and io.* cannot create parent directories, so the tree is made with a
+    -- direct libc call -- no shell, no os.execute. Declared once here.
+    pcall(ffi.cdef, "int mkdir(const char *path, unsigned int mode);")
+  end
 end
 
 -- The engine's save-root resolver. On the Brick (portable mode on) this
@@ -61,6 +67,7 @@ local MeshCache = {}
 local dataKey = "unconfigured"
 local dirty = false
 local compression = "unknown"
+local codec = nil          -- "lz4"/"zstd"/"MIX" behind the compressed files
 local MANIFEST = "cache.info"
 local BUILD_INFO = "build.info"
 -- Populated by ready() whenever it returns false, so a caller (the boot
@@ -136,7 +143,12 @@ local saveFailures = 0
 -- isolates adjacent same-class props; all derived meshes must be regenerated.
 -- 17: cache headers include the active ROM/data identity, so a Red/Blue/
 -- Yellow switch or a changed map dataset can never reuse old geometry.
-MeshCache.GEOMETRY_VERSION = 17
+-- 18: terrain/water payloads become QUANTIZED -- 11 bytes/vertex (int16
+-- position, u16 uv, u8 shade) instead of the 24-byte 6-float stream, ~54%
+-- smaller before the entropy codec. Aux (grass/flowers/figures) keeps the
+-- float layout. Every terrain/water file written before this bump must be
+-- discarded.
+MeshCache.GEOMETRY_VERSION = 18
 
 -- A small deterministic revision for the inputs that can change terrain
 -- output without changing the mesher. It is intentionally not a checksum:
@@ -264,6 +276,7 @@ function MeshCache.configure(data)
   dataKey = datasetRevision(data)
   dirty = false
   compression = "unknown"
+  codec = nil
   -- A new configuration starts a fresh session: drop any snapshot from a
   -- previous build so live identity() is authoritative until begin() runs.
   buildIdentity = nil
@@ -278,6 +291,13 @@ function MeshCache.compressionStatus()
   return compression
 end
 
+-- The codec behind the compressed payloads: "lz4", "zstd", "MIX" (a cache
+-- spanning codecs), or nil when nothing is compressed. Set by
+-- updateCompression when ready()/writeManifest scans the headers.
+function MeshCache.codec()
+  return codec
+end
+
 MeshCache.identity = identity
 
 -- ---------------------------------------------------------- availability
@@ -285,33 +305,17 @@ MeshCache.identity = identity
 local dirTried = false
 local dirTriedAt = 0            -- os.clock() of the last attempt
 local cacheDir = false          -- resolved once; false when unusable
-local dirBackend = nil          -- how the dir was created: "love" or "mkdir"
+local dirBackend = nil          -- how the dir was created: "love" or "ffi"
 
--- The shell commands that create the cache directory tree. Windows cmd has
--- no `mkdir -p`: it cannot create missing parents and errors when the
--- target already exists, so emit one guarded `if not exist ... mkdir ...`
--- per component below the drive root (each level idempotent -- creating a
--- missing level or skipping an existing one both exit cleanly). Everywhere
--- else a single POSIX `mkdir -p` (stderr silenced) is enough. Exported so
--- the headless suite can assert the exact commands without running cmd.exe.
-local function mkdirCommands(dir, sep)
-  if sep ~= "\\" then
-    local q = dir:gsub('"', '\\"')
-    return { 'mkdir -p "' .. q .. '" 2>/dev/null' }
-  end
-  local commands = {}
-  local acc = ""
-  for part in dir:gmatch("[^\\]+") do
-    if part ~= "" then
-      acc = acc == "" and part or (acc .. "\\" .. part)
-      if acc:match("^%a:\\") then
-        local q = acc:gsub('"', '\\"')
-        commands[#commands + 1] =
-          'if not exist "' .. q .. '" mkdir "' .. q .. '"'
-      end
-    end
-  end
-  return commands
+-- Create one directory level through libc (no shell). An already-existing
+-- level returns non-zero (EEXIST) and is not an error -- the caller treats
+-- this as best-effort and the write probe below decides. A host without the
+-- POSIX mkdir symbol (or without ffi) simply gets false and the fallback is
+-- skipped; portable-mode caching is already ffi-gated at available().
+local function mkdirOne(path)
+  if not (ffi and ffi.C) then return false end
+  local ok, rc = pcall(function() return ffi.C.mkdir(path, 493) end) -- 0755
+  return ok and rc == 0
 end
 
 function MeshCache.available()
@@ -350,11 +354,11 @@ end
 -- then verified with a real io write probe, so a folder that can be
 -- created but not written to is caught here instead of mid-build.
 --
--- A FAILURE is retried, not cached forever: one early os.execute hiccup
--- (a mid-boot SD-card mount, a shell under load) used to disable the
--- cache for the whole session. A success is cached for the session; a
--- failure only suppresses retries for one second, so the next boot check
--- or save re-attempts the mkdir instead of silently giving up.
+-- A FAILURE is retried, not cached forever: one early directory-creation
+-- hiccup (a mid-boot SD-card mount) used to disable the cache for the
+-- whole session. A success is cached for the session; a failure only
+-- suppresses retries for one second, so the next boot check or save
+-- re-attempts the mkdir instead of silently giving up.
 function MeshCache.dir()
   if cacheDir then return cacheDir end
   local clock = os.clock
@@ -395,23 +399,24 @@ function MeshCache.dir()
       return d
     end
   end
-  -- 2) mkdir fallback -- the only path in portable mode, and the retry
-  -- path when love.filesystem was unavailable or the folder unwritable.
-  -- io.* cannot create missing parents, so mkdir the tree like the
-  -- engine's portable filesystem does. Failure stays a silent no-op.
-  for _, command in ipairs(mkdirCommands(d, sep)) do
-    local ok = os.execute(command)
-    if not (ok == true or ok == 0) then return nil end
-  end
+  -- 2) libc mkdir fallback -- the only path in portable mode (the SD card
+  -- is outside love.filesystem's root), and the retry path when
+  -- love.filesystem was unavailable or the folder unwritable. Best-effort
+  -- per level; the write probe is what decides. Failure stays a silent
+  -- no-op.
+  mkdirOne(base .. sep .. "mod-derived")
+  mkdirOne(base .. sep .. "mod-derived" .. sep .. "potato_voxel")
+  mkdirOne(base .. sep .. "mod-derived" .. sep .. "potato_voxel"
+                    .. sep .. "meshes")
   if not probeWritable(d) then return nil end
   cacheDir = d
-  dirBackend = "mkdir"
+  dirBackend = "ffi"
   return d
 end
 
 -- Which backend created the cache directory: "love" (love.filesystem),
--- "mkdir" (shell commands), or nil (unresolved/unavailable). Shown in the
--- CACHE STATUS details box.
+-- "ffi" (libc mkdir, portable mode), or nil (unresolved/unavailable).
+-- Shown in the CACHE STATUS details box.
 function MeshCache.dirBackend()
   return dirBackend
 end
@@ -458,6 +463,7 @@ end
 function MeshCache.begin()
   dirty = true
   compression = "unknown"
+  codec = nil
   -- Snapshot the identity at the START of a build session. Every payload
   -- file and the manifest written by this session share this one identity,
   -- even if a live component (e.g. voidFill) changes mid-build. This removes
@@ -508,14 +514,23 @@ end
 
 -- Binary layout, little-endian throughout:
 --   raw format: "DSM" + format byte (1) + u32 fp-len + fp bytes + payload
---   LZ4 format: same header, then codec + raw length + packed length + hash
---   mesh payload:   u32 vertex count n, then n*6 floats
+--   compressed format: same header, then codec byte (1=lz4, 2=zstd) +
+--     raw length + packed length + hash, then the packed bytes
+--   mesh payload (terrain/water, v18):  u32 vertex count n, then n*11
+--     quantized bytes (i16 x/y/z, u16 u/v, u8 shade), u32 index count m,
+--     then m u32 indices
+--   aux/figures payload:               u32 n, then n*6 floats (unchanged)
 --   figures payload: u8 count, then per figure: u32 n, n*6 floats,
 --                    then f32 wx, f32 wz, f32 y, f32 w
 local MAGIC = "DSM"
 local RAW_FORMAT = 1
 local COMPRESSED_FORMAT = 2
 local LZ4_CODEC = 1
+local ZSTD_CODEC = 2
+-- codec byte -> love.data format name. ZSTD is reserved: the engine ships
+-- no zstd codec yet, but a file written by a build that does (or a later
+-- runtime) reads and is reported correctly here.
+local CODEC_NAMES = { [LZ4_CODEC] = "lz4", [ZSTD_CODEC] = "zstd" }
 local MAX_PAYLOAD = 512 * 1024 * 1024
 
 local function f32(v)
@@ -543,11 +558,11 @@ local function readU32(s, offset)
        + s:byte(offset + 2) * 65536 + s:byte(offset + 3) * 16777216
 end
 
-local function header(fp, format, rawLen, packedLen, checksum)
+local function header(fp, format, rawLen, packedLen, checksum, codec)
   local out = MAGIC .. string.char(format) .. u32(#fp) .. fp
   if format == COMPRESSED_FORMAT then
-    out = out .. string.char(LZ4_CODEC) .. u32(rawLen) .. u32(packedLen)
-         .. u32(checksum)
+    out = out .. string.char(codec or LZ4_CODEC) .. u32(rawLen)
+         .. u32(packedLen) .. u32(checksum)
   end
   return out
 end
@@ -574,7 +589,8 @@ local function parseHeader(s, totalLen)
     meta.packedLen = readU32(s, offset + 5)
     meta.checksum = readU32(s, offset + 9)
     offset = offset + 13
-    if meta.codec ~= LZ4_CODEC or length - offset + 1 ~= meta.packedLen then
+    if meta.codec == nil or CODEC_NAMES[meta.codec] == nil
+       or length - offset + 1 ~= meta.packedLen then
       return nil
     end
   end
@@ -610,7 +626,9 @@ local function unpackPayload(s, offset, meta)
   if meta.rawLen > MAX_PAYLOAD or meta.packedLen > #body then return nil end
   local data = love and love.data
   if not (data and data.decompress) then return nil end
-    local ok, raw = pcall(data.decompress, "string", "lz4", body)
+  local codecName = CODEC_NAMES[meta.codec]
+  if not codecName then return nil end
+  local ok, raw = pcall(data.decompress, "string", codecName, body)
   -- ponytail: no per-byte checksum -- a Lua loop over a 10-25MB payload is a
   -- 100ms+ hitch on every cold map transition. Truncation is caught by the
   -- packed-length check in parseHeader and the raw-length check here; corrupt
@@ -625,9 +643,15 @@ end
 local function packPayload(fp, body)
   local data = love and love.data
   if data and data.compress and #body >= 1024 then
-    local ok, packed = pcall(data.compress, "string", "lz4", body)
+    local ok, packed = pcall(data.compress, "string", "zstd", body)
     if ok and type(packed) == "string" and #packed < #body then
-      return header(fp, COMPRESSED_FORMAT, #body, #packed, 0) .. packed
+      return header(fp, COMPRESSED_FORMAT, #body, #packed, 0, ZSTD_CODEC)
+             .. packed
+    end
+    ok, packed = pcall(data.compress, "string", "lz4", body)
+    if ok and type(packed) == "string" and #packed < #body then
+      return header(fp, COMPRESSED_FORMAT, #body, #packed, 0, LZ4_CODEC)
+             .. packed
     end
   end
   return header(fp, RAW_FORMAT) .. body
@@ -638,6 +662,7 @@ local function repackRaw(path, fp, body, meta)
   local packed = packPayload(fp, body)
   if packed:byte(4) == COMPRESSED_FORMAT then
     compression = "unknown"
+    codec = nil
     pcall(writeFile, path, packed)
   end
 end
@@ -682,9 +707,9 @@ local function encodeMesh(n, srcPtr)
   return table.concat(parts)
 end
 
--- INDEXED payload: the vertex stream above, then a u32 vertex map
--- (m entries). Terrain and water meshes are stored this way (brick.11);
--- aux payloads never are (encodeMesh stays unindexed for them).
+-- INDEXED payload (float): the vertex stream above, then a u32 vertex map
+-- (m entries). Aux payloads (grass/flowers) are stored this way; terrain
+-- and water use the quantized encodeQuant instead (v18).
 local function encodeIndexed(n, srcPtr, m, idxPtr)
   local parts = { encodeMesh(n, srcPtr), u32(m or 0) }
   if not idxPtr or m == nil or m == 0 then return table.concat(parts) end
@@ -719,7 +744,7 @@ local function decodeMesh(s)
   return { n = n, str = s, ptr = floatsPtr(s, 4) }
 end
 
--- Decode an INDEXED mesh payload (terrain/water, brick.11+): the vertex
+-- Decode an INDEXED float mesh payload (aux, brick.11+): the vertex
 -- stream as decodeMesh reads it, then u32 index count + the u32 vertex
 -- map. Returns { n, str, ptr, m, istr, iptr } (m = index count; iptr a
 -- uint32_t* into the map), or nil when corrupt. Files written before
@@ -737,6 +762,142 @@ local function decodeIndexed(s)
   if n == 0 then return { n = 0, m = 0 } end
   local rec = { n = n, str = s, ptr = floatsPtr(s, 4), m = m }
   if m > 0 then rec.istr = s; rec.iptr = u32Ptr(s, voff + 4) end
+  return rec
+end
+
+-- ------------------------------------------------------------ quantization
+--
+-- The modern real-time-game answer to mesh storage: quantize each vertex
+-- attribute to the smallest width that carries it, instead of six 32-bit
+-- floats. The voxel world makes this near-lossless -- positions are integer
+-- pixels, texture coords sample a small atlas, and shade is baked ambient
+-- occlusion with 0.216-unit steps:
+--
+--   position  int16 x3   (exact: the grid is integer px, well inside range)
+--   texcoord  u16   x2   (0..65535 over [0,1]; sub-texel on a 128px atlas)
+--   shade     u8         (0..255 over [0,1]; sub-band for the AO steps)
+--
+-- 11 bytes/vertex vs 24 (~54% smaller) BEFORE the entropy codec, with no
+-- codec dependency and no shell -- it is plain integer packing, so it works
+-- on every platform the cache already runs on. Decode expands back to the
+-- same 6-float stream the GPU upload path consumes; nothing downstream
+-- knows the disk format changed. Terrain and water only (GEOMETRY_VERSION
+-- 18); aux payloads keep the float layout.
+local QUANT_STRIDE = 11
+
+local function putU16(b, p, v)
+  b[p] = v % 256
+  b[p + 1] = math.floor(v / 256) % 256
+end
+
+local function putI16(b, p, v)
+  putU16(b, p, v < 0 and (v + 65536) or v)
+end
+
+local function readU16(ptr, off)
+  return ptr[off] + ptr[off + 1] * 256
+end
+
+local function readI16(ptr, off)
+  local w = readU16(ptr, off)
+  return w >= 32768 and (w - 65536) or w
+end
+
+-- Encode a quantized INDEXED payload: u32 n, n*11 quantized vertex bytes,
+-- u32 m, m u32 indices -- the same shape encodeIndexed writes for floats.
+local function encodeQuant(n, srcPtr, m, idxPtr)
+  local parts = { u32(n or 0) }
+  if srcPtr and n and n > 0 then
+    local CHUNK = 16384
+    local vbytes = n * QUANT_STRIDE
+    local buf = ffi.new("uint8_t[?]", vbytes)
+    local src = ffi.cast("const float*", srcPtr)
+    local w, vi = 0, 0
+    while vi < n do
+      local c = math.min(CHUNK, n - vi)
+      for i = 0, c - 1 do
+        local base = (vi + i) * 6
+        local x = math.floor(src[base] + 0.5)
+        local y = math.floor(src[base + 1] + 0.5)
+        local z = math.floor(src[base + 2] + 0.5)
+        local u = math.floor(src[base + 3] * 65535 + 0.5)
+        local v = math.floor(src[base + 4] * 65535 + 0.5)
+        local sh = math.floor(src[base + 5] * 255 + 0.5)
+        if x < -32768 then x = -32768 elseif x > 32767 then x = 32767 end
+        if y < -32768 then y = -32768 elseif y > 32767 then y = 32767 end
+        if z < -32768 then z = -32768 elseif z > 32767 then z = 32767 end
+        if u < 0 then u = 0 elseif u > 65535 then u = 65535 end
+        if v < 0 then v = 0 elseif v > 65535 then v = 65535 end
+        if sh < 0 then sh = 0 elseif sh > 255 then sh = 255 end
+        putI16(buf, w, x)
+        putI16(buf, w + 2, y)
+        putI16(buf, w + 4, z)
+        putU16(buf, w + 6, u)
+        putU16(buf, w + 8, v)
+        buf[w + 10] = sh
+        w = w + QUANT_STRIDE
+      end
+      vi = vi + c
+      Budget.check()
+    end
+    parts[#parts + 1] = ffi.string(buf, vbytes)
+  end
+  parts[#parts + 1] = u32(m or 0)
+  if idxPtr and m and m > 0 then
+    local CHUNK = 65536
+    local off = 0
+    local remaining = m
+    while remaining > 0 do
+      local c = math.min(CHUNK, remaining)
+      local bytes = c * 4
+      local ibuf = ffi.new("char[?]", bytes)
+      ffi.copy(ibuf, idxPtr + off, bytes)
+      parts[#parts + 1] = ffi.string(ibuf, bytes)
+      off = off + c
+      remaining = remaining - c
+      Budget.check()
+    end
+  end
+  return table.concat(parts)
+end
+
+-- Decode a quantized payload into { n, buf, m, istr, idx } -- buf is a
+-- float[?] ffi buffer (the expanded 6-float stream, which meshFromData
+-- already accepts as the fresh-build shape) and idx a uint32_t* into the
+-- string. nil when corrupt.
+local function decodeQuant(s)
+  if not s or #s < 8 then return nil end
+  local n = readU32(s, 1)
+  local vbytes = n * QUANT_STRIDE
+  if n > 0 and #s < 4 + vbytes + 4 then return nil end
+  local fbuf
+  if n > 0 then
+    local CHUNK = 16384
+    fbuf = ffi.new("float[?]", n * 6)
+    local src = ffi.cast("const uint8_t*", ffi.cast("const char*", s))
+    local vi = 0
+    while vi < n do
+      local c = math.min(CHUNK, n - vi)
+      for i = 0, c - 1 do
+        local r = 4 + (vi + i) * QUANT_STRIDE
+        local fo = (vi + i) * 6
+        fbuf[fo] = readI16(src, r)
+        fbuf[fo + 1] = readI16(src, r + 2)
+        fbuf[fo + 2] = readI16(src, r + 4)
+        fbuf[fo + 3] = readU16(src, r + 6) / 65535
+        fbuf[fo + 4] = readU16(src, r + 8) / 65535
+        fbuf[fo + 5] = src[r + 10] / 255
+      end
+      vi = vi + c
+      Budget.check()
+    end
+  end
+  local voff = 4 + vbytes
+  local m = readU32(s, voff + 1)
+  if m > 0 and #s < voff + 4 + m * 4 then return nil end
+  if n == 0 then return { n = 0, m = m } end
+  local rec = { n = n, buf = fbuf, m = m }
+  if m > 0 then rec.istr = s; rec.idx = u32Ptr(s, voff + 4) end
   return rec
 end
 
@@ -780,7 +941,7 @@ local function payloadFingerprint(path, fp, kind, prefix)
   local body = unpackPayload(s, off, meta)
   if not body then return nil end
   if kind ~= "aux" then
-    return decodeIndexed(body) and got or nil
+    return decodeQuant(body) and got or nil
   end
   local grass = decodeIndexed(body)
   if not grass then return nil end
@@ -828,30 +989,34 @@ local function safeValidHeader(path, fp)
 end
 
 local function safeFormat(path, fp)
-  local ok, format, rawLen = pcall(function()
+  local ok, format, rawLen, codecName = pcall(function()
     local s, totalLen = readHeader(path)
     if not s then return nil end
     local got, offset, meta = parseHeader(s, totalLen)
     if got ~= fp then return nil end
     local rawLen = meta.format == COMPRESSED_FORMAT
                   and meta.rawLen or (totalLen - offset + 1)
-    return meta.format, rawLen
+    return meta.format, rawLen, CODEC_NAMES[meta.codec]
   end)
-  return ok and format or nil, ok and rawLen or nil
+  return ok and format or nil, ok and rawLen or nil, ok and codecName or nil
 end
 
 local function updateCompression(records, dir)
   local total, compressed = 0, 0
+  local codecNames = {}
   for _, record in pairs(records or {}) do
     for _, pair in ipairs({
       { record.terrain, record.terrainFp },
       { record.water, record.waterFp },
       { record.aux, record.auxFp },
     }) do
-      local format, rawLen = safeFormat(dir .. "/" .. pair[1], pair[2])
+      local format, rawLen, codecName = safeFormat(dir .. "/" .. pair[1], pair[2])
       if rawLen and rawLen >= 1024 then
         total = total + 1
-        if format == COMPRESSED_FORMAT then compressed = compressed + 1 end
+        if format == COMPRESSED_FORMAT then
+          compressed = compressed + 1
+          if codecName then codecNames[codecName] = true end
+        end
       end
     end
   end
@@ -863,6 +1028,17 @@ local function updateCompression(records, dir)
     compression = "raw"
   else
     compression = "mixed"
+  end
+  -- The codec behind the compressed payloads: one name when they all
+  -- agree, "MIX" when a cache spans codecs, nil when nothing is compressed.
+  local names = {}
+  for name in pairs(codecNames) do names[#names + 1] = name end
+  if #names == 1 then
+    codec = names[1]
+  elseif #names > 1 then
+    codec = "MIX"
+  else
+    codec = nil
   end
 end
 
@@ -1136,7 +1312,7 @@ function MeshCache.saveTerrain(map, slot, buf, n, idx, m)
   local path = fileFor(map, slot, "terrain")
   local ok, result = pcall(function()
     local fp = fingerprint(map, slot)
-    return writeFile(path, packPayload(fp, encodeIndexed(n, buf, m, idx)))
+    return writeFile(path, packPayload(fp, encodeQuant(n, buf, m, idx)))
   end)
   if not ok then
     os.remove(path .. ".tmp")
@@ -1151,7 +1327,7 @@ function MeshCache.saveWater(map, slot, buf, n, idx, m)
   local path = fileFor(map, slot, "water")
   local ok, result = pcall(function()
     local fp = fingerprint(map, slot .. "Water")
-    return writeFile(path, packPayload(fp, encodeIndexed(n, buf, m, idx)))
+    return writeFile(path, packPayload(fp, encodeQuant(n, buf, m, idx)))
   end)
   if not ok then
     os.remove(path .. ".tmp")
@@ -1185,7 +1361,7 @@ function MeshCache.loadMeshData(path, fp)
   end
   local body = unpackPayload(s, off, meta)
   if body then repackRaw(path, fp, body, meta) end
-  return body and decodeIndexed(body) or nil
+  return body and decodeQuant(body) or nil
 end
 
 -- Persist the aux (grass/flowers/figures) vertex streams. `flattened` is
@@ -1256,6 +1432,7 @@ end
 function MeshCache.invalidate(mapId)
   dirty = true
   compression = "unknown"
+  codec = nil
   local dir = MeshCache.dir()
   if not dir then return end
   os.remove(dir .. "/" .. MANIFEST)
@@ -1268,28 +1445,31 @@ function MeshCache.invalidate(mapId)
   end
 end
 
-local function listFiles(dir)
-  if not io.popen then return {} end
-  local quoted = dir:gsub('"', '\\"')
-  local command = package.config:sub(1, 1) == "\\"
-    and ('dir /b "' .. quoted .. '" 2>nul')
-    or ('ls -1 "' .. quoted .. '" 2>/dev/null')
-  local ok, pipe = pcall(io.popen, command, "r")
-  if not ok or not pipe then return {} end
-  local names = {}
-  for name in pipe:lines() do names[#names + 1] = name end
-  pipe:close()
-  return names
+local function listFiles()
+  -- Directory listing without a shell: love.filesystem enumerates the
+  -- folder when the cache lives under its root; the portable (SD-card)
+  -- folder is outside it and returns nothing, which is fine -- wipe()'s
+  -- direct pass below already removes every file the current job set
+  -- names, so the listing only catches stale files from maps no longer
+  -- present in the data.
+  if love and love.filesystem and love.filesystem.getDirectoryItems then
+    local ok, items = pcall(love.filesystem.getDirectoryItems,
+                            "mod-derived/potato_voxel/meshes")
+    if ok and type(items) == "table" then return items end
+  end
+  return {}
 end
 
 function MeshCache.wipe(jobs)
   dirty = true
   compression = "unknown"
+  codec = nil
   local dir = MeshCache.dir()
   if not dir then return false end
   os.remove(dir .. "/" .. MANIFEST)
-  -- The direct pass also works on platforms without io.popen. The directory
-  -- pass catches stale files from maps no longer present in the current data.
+  -- The direct pass also works where the directory listing cannot reach
+  -- (portable mode). The directory pass catches stale files from maps no
+  -- longer present in the current data.
   for _, job in ipairs(jobs or {}) do
     local prefix = tostring(job.id):gsub("[^%w_]", "_")
     for _, slot in ipairs({ "body", "full" }) do
@@ -1298,7 +1478,7 @@ function MeshCache.wipe(jobs)
       end
     end
   end
-  for _, name in ipairs(listFiles(dir)) do
+  for _, name in ipairs(listFiles()) do
     if name:match("%.terrain$") or name:match("%.water$")
        or name:match("%.aux$") or name:match("%.tmp$") then
       os.remove(dir .. "/" .. name)
@@ -1356,8 +1536,6 @@ end
 -- serialized bytes; decodeMesh reads them back.
 MeshCache.encodeMesh = encodeMesh
 MeshCache.decodeMesh = decodeMesh
--- mkdir command builder for MeshCache.dir, exported for tests
-MeshCache.mkdirCommands = mkdirCommands
 -- indexed terrain/water payloads (brick.11+)
 MeshCache.encodeIndexed = encodeIndexed
 MeshCache.decodeIndexed = decodeIndexed

--- a/lib/StadiumMon.lua
+++ b/lib/StadiumMon.lua
@@ -250,6 +250,12 @@ function StadiumMon:slotAnim(name)
   if not slot then return nil end
   local index = model.ctx[slot]
   if not index or index == StadiumPack.NONE then return nil end
+  -- a species whose entrance reads as a collapse (StadiumRig's scan, run at
+  -- load) is not sent out to the sound of it: it arrives on its standby
+  -- loop, which is exactly the fallback play() hands a missing entrance on
+  -- to. The entrance is the one slot with a verdict -- every other slot is
+  -- played as authored.
+  if name == "entrance" and model.collapseEntrance then return nil end
   return index + 1
 end
 

--- a/lib/StadiumRig.lua
+++ b/lib/StadiumRig.lua
@@ -486,6 +486,18 @@ StadiumRig.ANCHOR_STEADY = 0.5
 -- this module is below it and a require would be circular. Position 1 of
 -- StadiumPack.CONTEXT, which is the format's own contract.
 local IDLE_SLOT = 1
+-- And which one the send-out entrance is. Position 4 of the same contract.
+local ENTRANCE_SLOT = 4
+
+-- How deep an entrance may carry the body before it stops being an entrance
+-- and reads as a collapse (see measureBind's scan). Compared against the
+-- species' own standing height.
+StadiumRig.COLLAPSE_RATIO = 0.65
+
+-- The anchor limit the collapse scan poses with, in body-heights. The game
+-- value lives in StadiumMon.TRAVEL, and this module sits below StadiumMon,
+-- so the number is repeated here rather than required.
+local COLLAPSE_LIMIT = 0.75
 
 -- How much of the model each bone actually carries. Cached on the shared
 -- model: it is a fact about the mesh, not about this instance.
@@ -521,6 +533,22 @@ local function centre(self, n)
     end
   end
   return x / total, y / total, z / total
+end
+
+-- The highest bone origin in the pose, in the model's raw units: the "how
+-- tall is this Pokemon right now" number. Not the centre, because the body
+-- can stay centred while the whole Pokemon tips -- a flop reads as a
+-- collapse and the centre would not see it. The max is what the eye agrees
+-- with: a Pokemon whose top drops to half its standing height reads as
+-- crumpled, whatever its limbs are doing.
+local function bodyTop(self, n)
+  local d = self.drawM
+  local hi = -1e30
+  for b = 1, n do
+    local y = d[(b - 1) * 12 + 8]
+    if y > hi then hi = y end
+  end
+  return hi
 end
 
 -- Where the BIND pose puts it -- the spot every animation is measured
@@ -586,6 +614,44 @@ function StadiumRig:measureBind()
                        .. "not anchoring it, the measurement cannot be "
                        .. "trusted", tostring(model.species), worst)
       end
+    end
+  end
+
+  -- ------- and whether the send-out entrance reads as a collapse
+  --
+  -- The entrance is what plays when a Pokemon is sent out, and for most of
+  -- the set it is a flourish that ends on the standby pose. For a big
+  -- minority it is a drop: the body falls to well under its standing height
+  -- for a sustained stretch (Squirtle retreats into its shell, Goldeen lies
+  -- flat), which on a fixed tile at send-out reads as "hurt" -- and a
+  -- Pokemon arriving hurt is worse than arriving plainly. A species marked
+  -- here plays its standby loop at send-out instead of the entrance, the
+  -- same fallback a species with no entrance slot at all already gets (see
+  -- StadiumMon.play).
+  --
+  -- Measured WITH the anchor, because that is the picture the player sees
+  -- and the anchor is part of it: an entrance that hops beyond the limit is
+  -- dragged back on the way down (see anchor's clamp), which only deepens
+  -- the drop. Walked once here, like the idle above -- a few hundred poses
+  -- on a model that is about to be posed sixty times a second anyway.
+  local entr = model.ctx and model.ctx[ENTRANCE_SLOT]
+  local eanim = (entr and entr ~= 0xFFFF) and (entr + 1) or nil
+  local erec = eanim and model.anims and model.anims[eanim]
+  if erec and erec.frames and erec.frames > 1 then
+    self:pose(nil, 0, false)
+    local bindTop = bodyTop(self, model.boneCount)
+    local minTop = bindTop
+    self.anchorX, self.anchorY, self.anchorZ = nil, nil, nil
+    for f = 0, erec.frames - 1 do
+      self:pose(eanim, f, false)
+      if model.bindCX then self:anchor(COLLAPSE_LIMIT, 1 / 60) end
+      local t = bodyTop(self, model.boneCount)
+      if t < minTop then minTop = t end
+    end
+    -- and leave the anchor cold, so the real send-out starts from nowhere
+    self.anchorX, self.anchorY, self.anchorZ = nil, nil, nil
+    if bindTop > 0 and minTop / bindTop < StadiumRig.COLLAPSE_RATIO then
+      model.collapseEntrance = true
     end
   end
   -- and leave the bind pose behind, not the last frame of the idle
@@ -675,13 +741,22 @@ function StadiumRig:anchor(limit, dt)
     ox, oy, oz = dx * k, dy * k, dz * k
   end
 
-  -- and then toward it rather than straight to it (see ANCHOR_HALF_LIFE),
-  -- and never faster than ANCHOR_RATE
+  -- and then toward it rather than straight to it (see ANCHOR_HALF_LIFE)
   if dt and dt > 0 then
     local half = StadiumRig.ANCHOR_HALF_LIFE
     local a = (half > 0) and (1 - 0.5 ^ (dt / half)) or 1
     if a > 1 then a = 1 end
     local px, py, pz = self.anchorX or ox, self.anchorY or oy, self.anchorZ or oz
+    -- never correct further than the current excursion asks for. A lagged
+    -- offset that outlives the excursion it answered drags a hopping
+    -- Pokemon below the tile it just returned to -- which is the collapse
+    -- the entrance scan (see measureBind) keys on. This only ever shrinks
+    -- the correction, so the within-limit guarantee the anchor exists for
+    -- is untouched: the body is never pushed farther from the bind than
+    -- the pose itself has carried it.
+    if math.abs(ox) < math.abs(px) then px = ox end
+    if math.abs(oy) < math.abs(py) then py = oy end
+    if math.abs(oz) < math.abs(pz) then pz = oz end
     ox = px + (ox - px) * a
     oy = py + (oy - py) * a
     oz = pz + (oz - pz) * a

--- a/main.lua
+++ b/main.lua
@@ -912,8 +912,9 @@ end
 -- Build the complete PotatoVoxel-owned row set for the dedicated submenu.
 local function cacheReadyLabel(status)
   if status ~= "READY" then return status end
+  local codec = MeshCache.codec()
+  if codec then return "READY " .. codec:upper() end
   local mode = MeshCache.compressionStatus()
-  if mode == "compressed" then return "READY CMP" end
   if mode == "mixed" then return "READY MIX" end
   if mode == "raw" then return "READY RAW" end
   return "READY"
@@ -924,17 +925,21 @@ local function showCacheStatus(game)
   local status = CachePrebuild.status()
   local label = status
   if status == "READY" then
-    local mode = MeshCache.compressionStatus()
-    label = mode == "compressed" and "READY (COMPRESSED)"
-            or mode == "mixed" and "READY (MIXED)"
-            or mode == "raw" and "READY (RAW)"
-            or "READY"
+    local codec = MeshCache.codec()
+    if codec then
+      label = "READY (" .. codec:upper() .. ")"
+    else
+      local mode = MeshCache.compressionStatus()
+      label = mode == "mixed" and "READY (MIXED)"
+              or mode == "raw" and "READY (RAW)"
+              or "READY"
+    end
   end
-  -- which backend created the cache dir: the love.filesystem tree or the
-  -- mkdir shell fallback -- so a support report names the active path
+  -- which backend created the cache dir: love.filesystem or the libc
+  -- mkdir -- so a support report names the active path
   local backend = MeshCache.dirBackend()
   local backendLabel = backend == "love" and "LOVE FS"
-      or backend == "mkdir" and "MKDIR"
+      or backend == "ffi" and "FFI MKDIR"
       or "NONE"
   game.stack:push(TextBox.new(game,
     ("%s\fGEOMETRY %d\fDIR: %s"):format(label, MeshCache.GEOMETRY_VERSION,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -57,23 +57,8 @@ MeshCache.configure({ maps = maps, tilesets = {} })
 T.check(firstIdentity ~= MeshCache.identity(),
         "map data changes the cache identity")
 
-local posixMkdir = MeshCache.mkdirCommands(
-  "/home/user/.local/share/love/game/mod-derived/potato_voxel/meshes", "/")
-T.eq(type(posixMkdir), "table", "mkdir commands come back as a list")
-T.eq(#posixMkdir, 1, "POSIX tree creation is a single command")
-T.eq(posixMkdir[1],
-     'mkdir -p "/home/user/.local/share/love/game/mod-derived/potato_voxel/meshes" 2>/dev/null',
-     "POSIX uses mkdir -p with silenced stderr")
-local winMkdir = MeshCache.mkdirCommands(
-  "C:\\LOVE\\game\\mod-derived\\potato_voxel\\meshes", "\\")
-T.eq(#winMkdir, 5, "Windows creates each component below the drive root")
-T.eq(winMkdir[1], 'if not exist "C:\\LOVE" mkdir "C:\\LOVE"',
-     "Windows guards the drive-level folder")
-T.eq(winMkdir[2], 'if not exist "C:\\LOVE\\game" mkdir "C:\\LOVE\\game"',
-     "Windows guards each intermediate folder")
-T.eq(winMkdir[5],
-     'if not exist "C:\\LOVE\\game\\mod-derived\\potato_voxel\\meshes" mkdir "C:\\LOVE\\game\\mod-derived\\potato_voxel\\meshes"',
-     "Windows deepest component is the cache dir itself")
+T.check(MeshCache.mkdirCommands == nil,
+        "directory creation is shell-free (love.filesystem / libc mkdir)")
 
 local record = MeshCache.jobRecord({
   id = "A", tileset = { image = "tileset.png", trueColor = false },
@@ -141,7 +126,7 @@ local ffiOk, ffi = pcall(require, "ffi")
 local cacheDir = MeshCache.dir()
 if ffiOk and cacheDir then
   T.check(MeshCache.dirBackend() == "love"
-            or MeshCache.dirBackend() == "mkdir",
+            or MeshCache.dirBackend() == "ffi",
           "dir resolution records which backend created the folder")
   T.check(MeshCache.probeWritable(cacheDir),
           "the resolved cache dir passes a real io write probe")
@@ -185,7 +170,10 @@ if ffiOk and cacheDir then
   local packed = {}
   local serial = 0
   testLove.data = {
-    compress = function(_, _, body)
+    compress = function(_, format, body)
+      -- Simulate the shipped runtime: no zstd codec, lz4 only. A format
+      -- that is not lz4 returns nil so packPayload falls back to lz4.
+      if format ~= "lz4" then return nil end
       serial = serial + 1
       local key = "packed" .. serial
       packed[key] = body
@@ -195,8 +183,8 @@ if ffiOk and cacheDir then
   }
   _G.love = testLove
   MeshCache.configure({ maps = maps, tilesets = {} })
-  local vertices = ffi.new("float[?]", 64 * 6)
-  MeshCache.saveTerrain(fakeMap, "body", vertices, 64)
+  local vertices = ffi.new("float[?]", 128 * 6)
+  MeshCache.saveTerrain(fakeMap, "body", vertices, 128)
   local compressed = io.open(cacheDir .. "/A.body.terrain", "rb")
   local compressedFormat = compressed and compressed:read(4):byte(4) or nil
   if compressed then compressed:close() end
@@ -204,7 +192,7 @@ if ffiOk and cacheDir then
   MeshCache.saveWater(fakeMap, "body", nil, 0)
   MeshCache.saveAux(fakeMap, "body", { figures = {} })
   local loaded = MeshCache.loadTerrain(fakeMap, "body")
-  T.check(loaded ~= nil and loaded.n == 64,
+  T.check(loaded ~= nil and loaded.n == 128,
           "compressed cache payload loads through the normal decoder")
   local oldDecompress = testLove.data.decompress
   testLove.data.decompress = function()
@@ -214,9 +202,32 @@ if ffiOk and cacheDir then
           "compressed cache reports READY from headers")
   T.eq(MeshCache.compressionStatus(), "compressed",
        "cache status identifies compressed payloads")
+  T.eq(MeshCache.codec(), "lz4",
+       "cache status identifies the codec (lz4 fallback without zstd)")
   T.check(MeshCache.ready({ { id = "A", slot = "body" } }),
           "manifest READY check uses bounded payload headers")
   testLove.data.decompress = oldDecompress
+
+  -- A runtime WITH zstd: the same payload compressed as zstd writes codec
+  -- byte 2, and codec() reports "zstd" -- the READY (ZSTD) label path.
+  testLove.data.compress = function(_, format, body)
+    if format ~= "zstd" then return nil end
+    serial = serial + 1
+    local key = "zpacked" .. serial
+    packed[key] = body
+    return key
+  end
+  MeshCache.saveTerrain(fakeMap, "body", vertices, 128)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  local zloaded = MeshCache.loadTerrain(fakeMap, "body")
+  T.check(zloaded ~= nil and zloaded.n == 128,
+          "zstd-compressed payload loads through the codec-aware decoder")
+  T.check(MeshCache.ready({ { id = "A", slot = "body" } }),
+          "zstd cache reports READY from headers")
+  T.eq(MeshCache.codec(), "zstd",
+       "cache status identifies the zstd codec")
+
   testLove.data = oldData
   _G.love = oldLove
   MeshCache.wipe({ { id = "A", slot = "body" } })

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -173,6 +173,60 @@ if brick then
              "a big pack compresses into the container")
      T.eq(Pack.decompress(packed), raw, "a compressed pack round-trips")
    end
+   -- A species whose send-out entrance reads as a collapse (StadiumRig's
+   -- load-time scan marks it) must not be sent out to the sound of it:
+   -- the entrance request falls back to the standby loop, which is the
+   -- same fallback a species with no entrance slot already gets.
+   local StadiumMon = exports.lib.require("StadiumMon")
+   local function fakeMon(collapse)
+     local mon = StadiumMon.new("player")
+     mon.model = {
+       ctx = { [1] = 0, [4] = 1 },
+       anims = {
+         { seconds = 1, aux = -1 },
+         { seconds = 2, aux = -1 },
+       },
+       collapseEntrance = collapse,
+     }
+     mon:play("idle")
+     return mon
+   end
+   local clean = fakeMon(false)
+   T.check(clean:request("entrance"),
+           "a normal entrance request is accepted")
+   T.eq(clean.state, "entrance", "and plays the entrance state")
+   local collapse = fakeMon(true)
+   T.check(collapse:request("entrance"),
+           "a collapse-marked entrance request still lands")
+   T.eq(collapse.state, "idle",
+        "but arrives on its standby loop instead of the collapse")
+   T.eq(collapse.anim, 1, "the standby loop is the one that plays")
+   -- the anchor must not over-correct past the excursion that caused it:
+   -- a Pokemon that hops up and comes back is dragged below its tile on
+   -- the return by the lagged offset, which is the "hurt" the collapse
+   -- scan keys on.  A one-bone rig, hopped, then returned.
+   local StadiumRig = exports.lib.require("StadiumRig")
+   local am = {
+     rootScale = 1, height = 100, boneCount = 1,
+     bindCX = 0, bindCY = 0, bindCZ = 0, anchorOk = true,
+     boneW = { [1] = 1 }, boneWTotal = 1,
+   }
+   local function fakeRig()
+     local r = { model = am, pivotM = {}, drawM = {} }
+     for i = 1, 12 do r.pivotM[i], r.drawM[i] = 0, 0 end
+     return r
+   end
+   local rig = fakeRig()
+   rig.drawM[8] = 200                    -- hop a full body-height up
+   StadiumRig.anchor(rig, 0.75, 1 / 60)
+   StadiumRig.anchor(rig, 0.75, 1 / 60)
+   rig.drawM[8], rig.pivotM[8] = 0, 0    -- and the hop comes back
+   StadiumRig.anchor(rig, 0.75, 1 / 60)
+   T.eq(rig.drawM[8], 0,
+        "anchor clamps the offset to the current excursion, so a returned "
+        .. "hop is not dragged below the tile it came back to")
+   T.eq(rig.pivotM[8], 0,
+        "the pivot chain gets the same clamp as the draw chain")
    local Prebuild = exports.lib.require("CachePrebuild")
   local jobs = Prebuild.enumerate({ B = { id="B", width=3, height=2, connections={} }, A = { id="A", width=4, height=5, connections={} } })
   T.eq(#jobs, 4, "prebuild enumerates body and full variants")
@@ -304,17 +358,35 @@ if MeshCache and MeshCache.encodeMesh then
                       tileset = { image = "tilesets/sample.png", trueColor = false },
                       renderer = { gbcAtlas = true } }
     local rtBuf = ffi.new("float[?]", n * 6)
-    for i = 0, n * 6 - 1 do rtBuf[i] = (i + 1) * 0.5 end
+    for i = 0, n - 1 do
+      rtBuf[i * 6] = (i % 4) * 8                 -- x: integer px (exact)
+      rtBuf[i * 6 + 1] = math.floor(i / 4) * 4   -- y: integer height (exact)
+      rtBuf[i * 6 + 2] = (i % 3) * 8             -- z: integer px (exact)
+      rtBuf[i * 6 + 3] = ((i % 128) + 0.5) / 128 -- u: atlas texel centre
+      rtBuf[i * 6 + 4] = ((i % 48) + 0.5) / 48   -- v
+      rtBuf[i * 6 + 5] = 0.5 + (i % 10) / 20     -- shade: baked AO band
+    end
     MeshCache.saveTerrain(fakeMap, "full", rtBuf, n)
     local rtTerrain, rtWater = MeshCache.loadTerrain(fakeMap, "full")
     T.check(rtTerrain ~= nil and rtTerrain.n == n,
             "loadTerrain reads back the written mesh (header+payload offset)")
     if rtTerrain then
       local match = true
-      for i = 0, n * 6 - 1 do
-        if math.abs(rtTerrain.ptr[i] - (i + 1) * 0.5) > 1e-4 then match = false break end
+      for i = 0, n - 1 do
+        -- positions are integer pixels and round-trip exactly
+        if rtTerrain.buf[i * 6] ~= rtBuf[i * 6]
+           or rtTerrain.buf[i * 6 + 1] ~= rtBuf[i * 6 + 1]
+           or rtTerrain.buf[i * 6 + 2] ~= rtBuf[i * 6 + 2] then
+          match = false break
+        end
+        -- uv quantizes to u16, shade to u8 -- sub-visible error only
+        if math.abs(rtTerrain.buf[i * 6 + 3] - rtBuf[i * 6 + 3]) > 0.01
+           or math.abs(rtTerrain.buf[i * 6 + 4] - rtBuf[i * 6 + 4]) > 0.01
+           or math.abs(rtTerrain.buf[i * 6 + 5] - rtBuf[i * 6 + 5]) > 0.01 then
+          match = false break
+        end
       end
-      T.check(match, "loadTerrain stream is byte-identical to what was saved")
+      T.check(match, "loadTerrain round-trips quantized positions/uv/shade")
     end
     -- The AUX round-trip at scale. flattenQuads counts FLOATS while the
     -- payloads are vertex-counted; feeding k in as n made encodeMesh read


### PR DESCRIPTION
Release 1.4.6. Merging to main triggers the release workflow.

**Included** (1.4.6):
- **Performance** — terrain/water meshes stored quantized: 11 bytes/vertex (int16 position, u16 uv, u8 shade) vs the 24-byte float stream (~54% smaller before compression). GEOMETRY_VERSION 17 -> 18.
- **Changed** — the mesh cache no longer uses shell commands (`os.execute`/`io.popen`): cache dir is created via love.filesystem / libc `mkdir`, listing via `love.filesystem.getDirectoryItems`.
- **Changed** — CACHE STATUS now names the codec: `READY (LZ4)` / `READY (ZSTD)` / `READY (RAW)` / `READY (MIXED)`. The cache tries zstd first and falls back to lz4; the codec is recorded per file.
- Also picks up a one-line AntiAlias colour-reset hardening already in the tree.

**Also bundled** (the 1.4.5 Stadium entrance fix, which was never released):
- Stadium models no longer play a hurt/faint-looking animation on send-out (entrance-vs-collapse detection, see CHANGELOG [1.4.5]).

Tests: 73/73 cache, 111/111 main. modkit lint/validate/pack green.