### PR TITLE
Release 1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.4.8] - 2026-08-13
+
+### Fixed
+
+- The anti-aliasing fold reset the draw colour with a bare
+  `love.graphics.setColor()` call, and LÖVE 11.5 has no zero-argument form of
+  `setColor` -- it throws `bad argument #1 to 'setColor' (number expected,
+  got no value)`. The throw rode the voxel pipeline's draw path back up, and
+  the error handling disabled the whole voxel mode for the session: the game
+  kept running but the overworld drew flat. The fold now resets to explicit
+  white `setColor(1, 1, 1, 1)` -- the v1.4.4 behaviour -- so the
+  supersampling pass can no longer take the mode down with it.
+
 ## [1.4.7] - 2026-08-13
 
 ### Fixed

--- a/lib/AntiAlias.lua
+++ b/lib/AntiAlias.lua
@@ -229,7 +229,8 @@ function AntiAlias.resolve(canvas, w, h, slot)
   -- the scene canvas filters nearest for its usual 1:1 blit; the taps want
   -- linear, put back below so every other pass finds what it expects
   pcall(canvas.setFilter, canvas, "linear", "linear")
-  love.graphics.setColor()
+  -- white, explicit: LÖVE 11.5 setColor has no zero-argument form
+  love.graphics.setColor(1, 1, 1, 1)
   -- replace, not alpha-blend: this is an image-processing copy, and the alpha
   -- the shader worked out has to land as itself rather than be composited
   -- against whatever the target held

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -126,6 +126,54 @@ if brick then
   T.check(#ForestAtmos.setting.values >= 2, "FOREST FX ladder stays available")
   T.eq(AntiAlias.setting.values[1], 0, "AA defaults off")
   T.eq(#AntiAlias.setting.values, 3, "AA ladder stays available")
+  -- LÖVE 11.5 regression: the AA fold used to reset the draw colour with a
+  -- bare love.graphics.setColor(), which LÖVE rejects with "bad argument #1
+  -- to 'setColor' (number expected, got no value)". The throw rode the voxel
+  -- pipeline's draw path back up and the error handling disabled voxel for
+  -- the whole session. The fold must reset to explicit white -- and it must
+  -- survive a strict setColor stub that models LÖVE 11.5 exactly.
+  do
+    local oldLove = _G.love
+    local colorArgs
+    local targetCanvas
+    local function strictSetColor(...)
+      if select("#", ...) == 0 then
+        error("bad argument #1 to 'setColor' (number expected, got no value)")
+      end
+      colorArgs = { n = select("#", ...), ... }
+    end
+    _G.love = {
+      graphics = {
+        newCanvas = function(w, h)
+          local c = { w = w, h = h }
+          function c.getDimensions() return w, h end
+          function c.setFilter() end
+          function c.release() end
+          targetCanvas = c
+          return c
+        end,
+        newShader = function() return nil end,
+        getBlendMode = function() return "alpha", "alphamultiply" end,
+        setColor = strictSetColor,
+        setBlendMode = function() end,
+        setCanvas = function() end,
+        clear = function() end,
+        draw = function() end,
+        setShader = function() end,
+      },
+    }
+    local src = {}
+    function src.getDimensions() return 160, 160 end
+    function src.setFilter() end
+    local folded = AntiAlias.resolve(src, 37, 21, "aa-setColor-regression")
+    T.check(folded == targetCanvas,
+            "AA fold survives a strict LÖVE 11.5 setColor stub")
+    T.eq(colorArgs and colorArgs.n or 0, 4,
+         "the fold resets colour with explicit RGBA arguments")
+    T.eq(colorArgs and colorArgs[1] or 0, 1,
+         "the fold's colour reset is white")
+    _G.love = oldLove
+  end
   T.eq(WorldCurve.setting.values[1], 0, "V-CURVE defaults off")
   T.eq(#WorldCurve.setting.values, 4, "V-CURVE ladder stays available")
   T.eq(VoxelGrid.setting.values[1], false, "V-GRID defaults off")


### PR DESCRIPTION
## 1.4.8 fix — AA fold setColor crash

**Fixed:** the anti-aliasing fold reset the draw colour with a bare `love.graphics.setColor()` call. LÖVE 11.5 has no zero-argument form of `setColor` — it throws `bad argument #1 to 'setColor' (number expected, got no value)` — and the throw rode the voxel pipeline's draw path back up, so the error handling disabled the whole voxel mode for the session (game kept running, overworld drew flat). The fold now resets to explicit white `setColor(1, 1, 1, 1)`.

- `lib/AntiAlias.lua`: restore the arguments
- `manifest.json`: 1.4.8
- `CHANGELOG.md`: 1.4.8 entry
- `tests/potato_voxel_test.lua`: regression test running the fold under a strict LÖVE 11.5 `setColor` stub (fails with the exact reported error when the bug is present)

Verified locally: 114/114 + 73/73 + loading suite, modkit lint/validate clean.