### PR TITLE
Release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.5.2] - 2026-08-14
+
+### Fixed
+
+- The pinned DUSK and DAWN settings now have shadows. Both pins parked the
+  clock exactly ON the horizon, where the designed shadow fade (the last
+  12 degrees of elevation) had already taken the shadow strength to zero --
+  so a dusk or dawn look rendered the long clamped shadows at zero opacity:
+  a completely flat-lit world. The pins now stop at the last fully-lit
+  moment -- the edge of the fade, where strength is exactly full and the
+  shear is clamped to the 1.5x stretch cap -- so dusk and dawn read as the
+  long-shadow golden hour they are. The RUNNING cycle keeps its soft
+  shadowless handoff gap at the true horizon, and the sky palettes are
+  unchanged (the pins land inside the golden/dawn blends).
+
 ## [1.5.1] - 2026-08-14
 
 ### Fixed

--- a/lib/DayNight.lua
+++ b/lib/DayNight.lua
@@ -6,7 +6,9 @@
 -- dial, not separate looks -- or lets it run (CYCLE), in which case the pin
 -- the player left is where the cycle picks up. Everything below is a pure
 -- function of the clock, so the pinned settings and the running cycle can
--- never drift apart: DUSK is simply the cycle stopped at sunset.
+-- never drift apart: DUSK is the cycle stopped at the last fully-lit
+-- moment of sunset (the shadow-fade edge -- see RISE_RAMP), because a pin
+-- on the exact horizon reads as "no shadows at all".
 --
 -- THE SUN's noon is this mod's existing sun, exactly: shear (-0.85, -0.55),
 -- hanging in the southeast about 45 degrees up. That is the DAY setting and
@@ -57,8 +59,10 @@ DayNight.CYCLE = 1200         -- seconds around the whole dial
 DayNight.DAY_LEN = 600        -- the sun's half; the moon has the rest
 DayNight.BLEND = 75           -- seconds of palette blend either side of a twilight
 
--- where the pinned settings stop the clock
-DayNight.T = { dawn = 0, day = 300, dusk = 600, night = 900 }
+-- where the pinned settings stop the clock. dawn/dusk are computed
+-- below (they sit at the shadow-fade edge, not on the horizon -- see
+-- RISE_RAMP); day is noon and night is the moon at mid-night.
+DayNight.T = { day = 300, night = 900 }
 
 DayNight.KEY = "daytime"
 DayNight.LABEL = "DAYTIME"
@@ -109,6 +113,19 @@ DayNight.ALPHA_SUN = 0.40     -- the existing midday shadow weight
 DayNight.ALPHA_MOON = 0.26    -- moonlight is a softer press
 DayNight.FADE_DEG = 12        -- shadows fade out over the last degrees of a rise/set
 
+-- Where the pinned DUSK and DAWN settings stop the clock: NOT on the
+-- horizon. The shadow strength fades to nothing over the last FADE_DEG
+-- degrees of elevation, so a pin parked exactly at sunrise/sunset reads
+-- as a world with NO shadows at all -- the long dusk shadows the pin is
+-- FOR, times zero opacity. The pins sit at the last fully-lit moment
+-- instead (el == FADE_DEG, where strength is exactly 1 and the shear is
+-- clamped to K_MAX): long shadows, a low sun, a golden sky. The RUNNING
+-- cycle keeps its soft shadowless handoff gap at the true horizon.
+local RISE_RAMP = DayNight.DAY_LEN / math.pi
+                * math.asin(DayNight.FADE_DEG / EL_NOON)
+DayNight.T.dawn = RISE_RAMP
+DayNight.T.dusk = DayNight.DAY_LEN - RISE_RAMP
+
 -- disc PLACEMENT only: the true elevation would put the noon sun far above
 -- any frame, so the arc the discs ride is squashed toward the horizon. The
 -- shadows always use the true elevation.
@@ -122,8 +139,8 @@ end
 
 -- The body lighting the world at clock `t`: bearing and elevation in
 -- degrees, and whether it is the moon. The t == DAY_LEN boundary belongs to
--- the SUN, so the pinned DUSK setting is the sun half-set in the northwest,
--- not the moon rising.
+-- the SUN, so the pinned DUSK setting is the sun low in the northwest (at
+-- the shadow-fade edge), not the moon rising.
 function DayNight.bodyAt(t)
   t = t % DayNight.CYCLE
   if t <= DayNight.DAY_LEN then
@@ -205,9 +222,11 @@ DayNight.MOON_COLORS = { { 240, 244, 248 }, { 224, 232, 240 },
                          { 168, 184, 208 }, { 120, 136, 168 } }
 
 -- The dial as keyframes: a repeated name is a plateau, a change is a
--- BLEND-wide ramp. Laid out so DUSK and DAWN proper land exactly on their
--- pinned times, and so the evening approaches dusk THROUGH the golden-hour
--- waypoint rather than straight across the grey between blue and gold. The
+-- BLEND-wide ramp. The DUSK and DAWN pins land inside the golden/dawn
+-- blends (they sit at the shadow-fade edge, BLEND-seconds shy of the
+-- horizon keyframes), so a pinned dusk reads as the golden hour it is.
+-- The evening approaches dusk THROUGH the golden-hour waypoint rather
+-- than straight across the grey between blue and gold. The
 -- morning side needs no waypoint of its own: dawn's pinks into day's blues
 -- share a family and blend clean.
 local DIAL

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -20,6 +20,7 @@ if brick then
   local Structures = exports.lib.require("Structures")
   local OverworldBattle = exports.lib.require("OverworldBattle")
   local QualityMode = exports.lib.require("QualityMode")
+  local DayNight = exports.lib.require("DayNight")
   T.eq(#Voxel.ANGLES_DEG, 6, "VOXEL keeps OFF/HIGH/MEDIUM/LOW/POTATO/CUSTOM")
   T.eq(Voxel.ANGLE_LABELS[1], "OFF", "VOXEL OFF rung is retained")
   T.eq(Voxel.ANGLE_LABELS[2], "HIGH", "VOXEL HIGH rung is retained")
@@ -155,6 +156,30 @@ if brick then
   if not ShadowMap.available() then
     T.check(type(ShadowMap.unavailableReason()) == "string",
             "a disabled shadow pass names its reason")
+  end
+  -- DUSK/DAWN pins sit at the last fully-lit moment, not on the horizon:
+  -- a pin on the exact horizon rides the shadow fade down to strength
+  -- zero and reads as "no shadows in dusk/dawn"
+  T.check(DayNight.T.dawn > 0 and DayNight.T.dawn < DayNight.T.day,
+          "DAWN pins inside the day")
+  T.check(DayNight.T.dusk > DayNight.T.day
+          and DayNight.T.dusk < DayNight.DAY_LEN,
+          "DUSK pins inside the day")
+  T.check(DayNight.strengthAt(DayNight.T.dawn) > 1 - 1e-9,
+          "DAWN has full shadow strength")
+  T.check(DayNight.strengthAt(DayNight.T.dusk) > 1 - 1e-9,
+          "DUSK has full shadow strength")
+  T.check(DayNight.strengthAt(0) < 1e-9,
+          "the cycle's dawn horizon gap stays shadowless")
+  T.check(DayNight.strengthAt(DayNight.DAY_LEN) < 1e-9,
+          "the cycle's dusk horizon gap stays shadowless")
+  do
+    local dkx, dkz = DayNight.shearAt(DayNight.T.dusk)
+    T.check(math.sqrt(dkx * dkx + dkz * dkz) <= DayNight.K_MAX + 1e-9,
+            "DUSK shadows obey the stretch clamp")
+    local akx, akz = DayNight.shearAt(DayNight.T.dawn)
+    T.check(math.sqrt(akx * akx + akz * akz) <= DayNight.K_MAX + 1e-9,
+            "DAWN shadows obey the stretch clamp")
   end
   T.eq(Water.setting.values[1], "off", "WATER defaults off")
   T.eq(#Water.setting.values, 3, "WATER ladder stays available")


### PR DESCRIPTION
Pinned DUSK/DAWN settings parked the clock exactly on the horizon, where the designed shadow fade (last 12 degrees of elevation) had already taken shadow strength to zero -- a flat-lit world with no shadows. The pins now stop at the last fully-lit moment (the fade edge): full shadow strength, shear clamped to the 1.5x cap, golden/dawn sky palettes unchanged. The running cycle keeps its soft shadowless handoff gap at the true horizon. Suite: 144/144 with new pin/strength/handoff checks.