### PR TITLE
fix: apply the cache-load index map in one call

### DIFF
--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -115,7 +115,8 @@ end
 -- pre-sandbox table build used.
 -- Slice a table upload across frames: the mesh is created with the full
 -- vertex count, then vertices and the index map land in budgeted pieces
--- (setVertices/setVertexMap accept a start index). The old ffi sink
+-- (setVertices accepts a start index; setVertexMap does NOT, so the
+-- index map is applied in one call). The old ffi sink
 -- sliced exactly this way; a one-shot newMesh(rows) on a 500k-vertex
 -- map is a 100-500ms hitch in pure Lua, which is what the sliced path
 -- exists to avoid. Budget.check() is a no-op outside the build
@@ -140,16 +141,17 @@ local function uploadTableMesh(rows, indices)
     Budget.check()
   end
   if indices and #indices > 0 then
-    local m = #indices
-    local k = 0
-    while k < m do
-      local c = math.min(UPLOAD_CHUNK * 2, m - k)
-      local slice = {}
-      for j = 1, c do slice[j] = indices[k + j] end
-      pcall(mesh.setVertexMap, mesh, slice, k + 1)
-      k = k + c
-      Budget.check()
+    -- Mesh:setVertexMap has no start-index overload -- LOVE 11.x offers
+    -- setVertexMap(map), setVertexMap(vi1, vi2, ...) and
+    -- setVertexMap(data, datatype) only, so a sliced call threw every
+    -- time and the pcall swallowed it. Apply it once.
+    local mapped = pcall(mesh.setVertexMap, mesh, indices)
+    if not mapped then
+      -- An unindexed quad stream becomes giant cross-quad triangles.
+      if mesh.release then pcall(mesh.release, mesh) end
+      return nil
     end
+    Budget.check()
   end
   return mesh
 end

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -440,7 +440,14 @@ function Voxel3D.newMesh(verts, map)
   local ok, mesh = pcall(love.graphics.newMesh, Voxel3D.FORMAT, verts,
                          "triangles", "static")
   if not ok then return nil end
-  if map and #map > 0 then pcall(mesh.setVertexMap, mesh, map) end
+  if map and #map > 0 then
+    local mapped = pcall(mesh.setVertexMap, mesh, map)
+    if not mapped then
+      -- An unindexed quad stream becomes giant cross-quad triangles.
+      if mesh.release then pcall(mesh.release, mesh) end
+      return nil
+    end
+  end
   return mesh
 end
 


### PR DESCRIPTION
Mesh:setVertexMap has no start-index overload. LOVE 11.x offers setVertexMap(map), setVertexMap(vi1, vi2, ...) and setVertexMap(data, datatype) only, so uploadTableMesh's

    pcall(mesh.setVertexMap, mesh, slice, k + 1)

matched the Data form with a table where Data was wanted and a number where a datatype string was wanted. Every call threw, the pcall swallowed it, and the index map was never applied -- including the first chunk. The mesh then drew unindexed, which 1.6.0's own comment describes as "giant cross-quad triangles".

Only the cache-load path is affected: the live build still goes through Voxel3D.newMesh and its correct one-argument form. That matches the symptom -- a map renders correctly when freshly meshed and breaks on the next visit when it loads from cache, at identical vertex counts.

Apply the map in a single call. Vertex upload keeps its slicing; setVertices does take a start index.

Also restores the failed-map guard in Voxel3D.newMesh that 1.6.0 had and current main dropped, so neither path can silently ship an unindexed mesh.

Verified on macOS (engine 0.1.92) and on an Anbernic RG35XXSP running muOS with a transplanted 222-map cache. Tests: sandbox_api_test, voxel_loading_test, shadow_golden all pass.