### PR TITLE
docs: clarify debug log upload consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ stale render time.
 
 - 1.6.2 — F8 export can send the debug log to the mod's `log_url` (opt-in
   via manifest; no-ops without the engine feature).
+- Pressing F8 sends that diagnostic log over the internet to the PotatoVoxel
+  maintainer through the project's log service, so I can review it directly
+  and help troubleshoot your game. Nothing is uploaded automatically: if you
+  do not press F8, the log stays local to the game.
 - The debugger now records from boot in the background; F9 only shows or
   hides the panel, so support logs include failures that happen before the
   first manual toggle.


### PR DESCRIPTION
Clarify the player-facing changelog and release wording for F8 diagnostic uploads.

It now explains that pressing F8 sends the diagnostic log over the internet to the PotatoVoxel maintainer through the project log service, and that no upload occurs automatically.

Validation: git diff --check.