### PR TITLE
Release 1.6.5: opt-in consent prompt for F8 log uploads

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -14,3 +14,4 @@ tests/goldens/shadow_golden.txt
 
 # Repo-only: issue templates must never ship in the mod zip.
 .github
+tests/shadow_runtime_test.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## [1.6.4] - 2026-08-16
+
+The map-corruption and cold-cache release: the two most-reported issues
+on 15-16 August are fixed here, plus the F8 pipeline now tells us why.
+
+### Fixed: broken/black terrain meshes
+
+- The budgeted index-map upload called Mesh:setVertexMap with a start
+  index LOVEs API does not have, and the error was swallowed -- every
+  slice replaced the whole map, so meshes kept only the final chunk's
+  indices ("giant cross-quad triangles", black ground with the map
+  visible in slivers, MT MOON/Cerulean reports). Indices now upload in
+  one call; vertices stay budget-sliced.
+
+### Fixed: cache rebuilt on every launch
+
+- The engine's boot asset handoff invalidated the whole mesh cache
+  (manifest dropped, cache marked dirty), forcing a full 444-job
+  prebuild every boot -- the "choppy boot loads" and "fails the
+  prebuild every time" reports. The first asset invalidation after boot
+  is now a no-op; restarts stay warm, and fingerprint protection still
+  covers real changes.
+
+### Debugger / support
+
+- F8 payload now carries an identity header (mod, engine, love, session,
+  frame) and a status excerpt (counters, pipeline, voxel, shadows,
+  cache, prebuild, worst frame, storage) so a received log is
+  attributable and self-diagnosing.
+- Send results are recorded: "log send confirmed" or "log send failed:
+  <engine error>" -- the engine's rejection reason is shown instead of a
+  bare failure.
+- Payloads are trimmed to the engine ceiling (newest lines kept), with a
+  conservative retry for engines that still cap at 64 KiB.
+- Blank-world reports name the exit path; a loading canvas stuck over
+  10s escalates to a durable error; pipeline availability carries the
+  reason.
+- Hold chords: five seconds of SELECT toggles the debug panel, five
+  seconds of START exports the log (touch/pad F9/F8). The SELECT chord
+  is gated off mobile so gameplay cannot summon the panel.
+- VOXEL SETTINGS gains a DEBUGGER toggle and a SEND LOGS action row.
+
+### Cache/prebuild
+
+- zlib joins the codec ladder (zstd -> zlib -> lz4): 3-4x smaller
+  payloads on runtimes without zstd, shorter writes and loads.
+- Payload verification is header-only (no full decode stall).
+- A single failed prebuild job no longer aborts the build; the next
+  boot resumes exactly the missing jobs (scan-based resume).
+- The slow-load counter is wired (it was declared but never counted).
+
+### Shadows / rendering
+
+- Shadow and voxel shaders pin effect parameters to mediump first with
+  a bare-precision retry for mobile compilers; shader errors and the
+  precision chosen are retained for diagnostics.
+- A failed shadow sprite pass can no longer erase an already-finished
+  world map.
+
+## [1.6.3] - 2026-08-15
+
+- Add opt-in F8 debug log uploads: pressing F8 sends the diagnostic log
+  to the PotatoVoxel log service (desktop, engine v0.1.95+). Nothing is
+  uploaded automatically.
+
+
 ## [1.6.2] - 2026-08-15
 
 Prebuild and diagnostics hardening: one bad job no longer fails the whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.6.5] - 2026-08-16
+
+### Diagnostics / privacy
+
+- F8 / SEND LOGS ask before the first upload: the first export that
+  would send shows a one-time prompt (the log goes to the mod's
+  developer over the internet), defaults to NO, and a YES is stored in
+  the mod's options so it is never asked again. A NO ships nothing and
+  asks again next time; engines with no log_url never prompt.
+
 ## [1.6.4] - 2026-08-16
 
 The map-corruption and cold-cache release: the two most-reported issues

--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ only one may run at a time.
 
 ## Diagnostics (hidden)
 
-F9 toggles a debug overlay (off by default), F10 switches its detail
-level, F8 exports its log. It exists for support reports and is silent
-unless turned on.
+The debugger records diagnostics in the background from boot. F9 shows or
+hides its panel, F10 switches its detail level, and F8 exports its log plus a
+capability probe. The export preserves early boot evidence, recent runtime
+lines, and a data-only `debug/status` record containing pipeline eligibility,
+shader/canvas reasons, renderer information, cache/storage state, and world
+render-path counters. It does not add a visible panel until you press F9.
 
 ## Develop & test
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ lines, and a data-only `debug/status` record containing pipeline eligibility,
 shader/canvas reasons, renderer information, cache/storage state, and world
 render-path counters. It does not add a visible panel until you press F9.
 
+The first export that would send a log to the mod's log service (F8, the
+START hold chord, or SEND LOGS in VOXEL SETTINGS) asks first: a one-time
+prompt explains that the log goes to the mod developer over the internet
+and defaults to NO. Accepting stores the decision in the mod's options,
+so later exports never ask again; declining ships nothing.
+
 ## Develop & test
 
 From the engine checkout root:

--- a/lib/CachePrebuild.lua
+++ b/lib/CachePrebuild.lua
@@ -321,15 +321,34 @@ function Prebuild.update()
   local jobStatus = ChunkMesher.jobStatus(job.id, bodyOnly)
   if jobStatus == "pending" then return end
   if jobStatus ~= "complete" or not MeshCache.verifyJob(state.slot, job.slot) then
-    state.failed = true
-    state.error = jobStatus
-      or MeshCache.saveError()
+    -- A single bad job must not abort the whole build: record it, release
+    -- the map, and move on. writeProgress has already left a manifest
+    -- naming every job that survived, so the next boot's resume set
+    -- retries exactly this job -- the ones around it are NOT rebuilt from
+    -- scratch (this was a full rebuild every boot when one aux save
+    -- failed). Only an epidemic aborts: a platform-wide storage failure is
+    -- better reported as FAILED than ground through job by job.
+    state.failedJobs = (state.failedJobs or 0) + 1
+    local maxFailures = math.max(4, math.floor(state.total / 10))
+    local reason = jobStatus or MeshCache.saveError()
       or "cache verification failed"
     local okD, Overlay = pcall(V.require, "DebugOverlay")
     if okD and Overlay then
-      Overlay.error("prebuild job failed: %s", tostring(state.error))
+      Overlay.error("prebuild job failed (%d/%d): %s -- %s/%s",
+                    state.failedJobs, state.total, tostring(reason),
+                    tostring(job.id), tostring(job.slot))
     end
-    finish(false)
+    if state.failedJobs > maxFailures then
+      state.failed = true
+      state.error = ("%d jobs failed"):format(state.failedJobs)
+      finish(false)
+      return
+    end
+    releaseMap(job.id, state.game)
+    state.done = state.done + 1
+    state.index = state.index + 1
+    state.slot = nil
+    if state.done >= state.total then finish(false) end
     return
   end
   state.completed[tostring(job.id) .. "/" .. tostring(job.slot)] =

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -114,8 +114,9 @@ end
 -- finish() uploads through Voxel3D.newMesh, the exact path the
 -- pre-sandbox table build used.
 -- Slice a table upload across frames: the mesh is created with the full
--- vertex count, then vertices and the index map land in budgeted pieces
--- (setVertices/setVertexMap accept a start index). The old ffi sink
+-- vertex count, then vertices land in budgeted pieces. The vertex map must
+-- be uploaded in one call: setVertexMap replaces the complete map and has no
+-- ranged-update form. The old ffi sink
 -- sliced exactly this way; a one-shot newMesh(rows) on a 500k-vertex
 -- map is a 100-500ms hitch in pure Lua, which is what the sliced path
 -- exists to avoid. Budget.check() is a no-op outside the build
@@ -140,16 +141,7 @@ local function uploadTableMesh(rows, indices)
     Budget.check()
   end
   if indices and #indices > 0 then
-    local m = #indices
-    local k = 0
-    while k < m do
-      local c = math.min(UPLOAD_CHUNK * 2, m - k)
-      local slice = {}
-      for j = 1, c do slice[j] = indices[k + j] end
-      pcall(mesh.setVertexMap, mesh, slice, k + 1)
-      k = k + c
-      Budget.check()
-    end
+    pcall(mesh.setVertexMap, mesh, indices)
   end
   return mesh
 end
@@ -177,6 +169,7 @@ local function newTableSink()
     buffer = function()
       local flat = {}
       for i, row in ipairs(verts) do
+        if (i % 4096) == 0 then Budget.check() end
         local b = (i - 1) * 6 + 1
         flat[b] = row[1]
         flat[b + 1] = row[2]
@@ -186,7 +179,10 @@ local function newTableSink()
         flat[b + 5] = row[6]
       end
       local imap = {}
-      for i, v in ipairs(indices) do imap[i] = v end
+      for i, v in ipairs(indices) do
+        if (i % 65536) == 0 then Budget.check() end
+        imap[i] = v
+      end
       return flat, #verts, imap, #indices
     end,
     finish = function()
@@ -1651,6 +1647,23 @@ function ChunkMesher.invalidate(mapId)
   end
 end
 
-Assets.register(function() ChunkMesher.invalidate() end)
+-- The engine fires every registered invalidator at boot too: the mod
+-- loader's Assets.installLoader -> Assets.invalidate handoff runs on
+-- every launch.  That first call is an asset-search-path handoff, not a
+-- geometry change -- no map has loaded yet -- and a full
+-- MeshCache.invalidate() there would drop the manifest and force a cold
+-- 444-job prebuild on every boot (observed: 162s rebuilds on Linux).
+-- The runtime mesh cache is empty at that point, and the disk cache is
+-- fingerprint-protected, so skipping exactly the first callback keeps
+-- restarts warm while real asset changes (dev hot reload) still empty
+-- the mesh cache.
+local bootAssetsHandedOff = false
+Assets.register(function()
+  if not bootAssetsHandedOff then
+    bootAssetsHandedOff = true
+    return
+  end
+  ChunkMesher.invalidate()
+end)
 
 return ChunkMesher

--- a/lib/DebugOverlay.lua
+++ b/lib/DebugOverlay.lua
@@ -153,6 +153,76 @@ local function logText()
   return table.concat(out, "\n")
 end
 
+-- Identity header for the remote payload.  The server's filename only
+-- carries the client id, so without this a received log cannot be
+-- attributed to an engine build, a mod version, or a session.
+local function headerText()
+  local mod = V.mod
+  local manifest = mod and mod.manifest
+  local ctx = health.storage.context or {}
+  local lv = health.renderer and health.renderer.love
+  local loveVer = lv and (tostring(lv.codename) .. " " .. tostring(lv.major)
+    .. "." .. tostring(lv.minor)) or "?"
+  return ("-- potato_voxel diagnostic send --\nmod: %s %s\nengine: %s\nlove: %s\nsession: %s\nframe: %s")
+    :format(tostring(manifest and manifest.name or "potato_voxel"),
+            tostring(manifest and manifest.version or "?"),
+            tostring(ctx.engineVersion or "?"),
+            loveVer, tostring(sessionId), tostring(health.frame))
+end
+
+-- Flat status excerpt.  The ring only covers what has happened since boot,
+-- so a send made early in a session would otherwise carry no rendering,
+-- prebuild, or cache evidence; the snapshot aggregates all of it.  The
+-- playthroughId stays local: the upload adds no identifiers.
+local function snapshotText()
+  local out = {}
+  local function kv(label, value)
+    out[#out + 1] = label .. ": " .. tostring(value)
+  end
+  local c = counters
+  kv("counters", ("jobs=%d errors=%d jobFails=%d cacheHits=%d slowLoads=%d storageFails=%d")
+    :format(c.jobs, c.errors, c.jobFails, c.cacheHits, c.slowLoads, c.storageFails))
+  local p = health.pipeline
+  if p then
+    kv("pipeline", ("availability=%s reason=%s level=%s rendered=%d path=%s")
+      :format(tostring(p.availability), tostring(p.reason), tostring(p.level),
+              p.rendered or 0, tostring(p.lastPath)))
+    if p.lastPathDetail then
+      kv("lastRender", ("renderMs=%s frame=%s")
+        :format(tostring(p.lastPathDetail.renderMs), tostring(p.lastPathFrame)))
+    end
+  end
+  local v = health.capabilities and health.capabilities.voxel
+  if v then
+    kv("voxel", ("available=%s reason=%s")
+      :format(tostring(v.available), tostring(v.reason)))
+  end
+  local pr = health.probe and health.probe.result
+  if pr then
+    if pr.shadows then
+      kv("shadows", ("available=%s reason=%s resolution=%s")
+        :format(tostring(pr.shadows.available), tostring(pr.shadows.reason),
+                tostring(pr.shadows.resolution)))
+    end
+    if pr.cache then
+      kv("cache", ("identity=%s saveFailures=%d")
+        :format(tostring(pr.cache.identity or "?"), pr.cache.saveFailures or 0))
+    end
+    if pr.prebuild then
+      kv("prebuild", ("status=%s %s/%s")
+        :format(tostring(pr.prebuild.status), tostring(pr.prebuild.done),
+                tostring(pr.prebuild.total)))
+    end
+  end
+  kv("worstFrame", worstFrame)
+  local st = health.storage
+  if st then
+    kv("storage", ("state=%s writes=%d failures=%d")
+      :format(tostring(st.state), st.writes or 0, st.failures or 0))
+  end
+  return table.concat(out, "\n")
+end
+
 local function managerLog(kind, msg)
   local mod = V.mod
   local logger = mod and mod.log
@@ -411,12 +481,25 @@ end
 -- always land in the background log and the console; hiding does not clear
 -- the ring buffer, so reopening shows what happened while it was hidden.
 function Overlay.toggle()
-  visible = not visible
+  Overlay.setVisible(not visible)
+end
+
+-- The DEBUGGER option row and the mod manager's page land on the same
+-- flag as F9: an explicit show/hide that records the same boundary line.
+function Overlay.setVisible(show)
+  show = show and true or false
+  if visible == show then return end
+  visible = show
   if not visible then Overlay.summary() end
   local line = "debugger " .. (visible and "VISIBLE" or "HIDDEN")
   append(stamp(line))
   pcall(print, "[pv-debug] " .. stamp(line))
   persist(true)
+end
+
+-- Current panel state, for a caller that wants to stay in step with F9.
+function Overlay.visible()
+  return visible
 end
 
 -- F10: verbose <-> important-only.
@@ -431,23 +514,66 @@ end
 -- polled once on the next frame and released when it settles, so a hung
 -- endpoint never accumulates in the worker pool.
 local sendHandle = nil
+local sendAt = 0   -- wall clock when the current send was submitted
 
 function Overlay.sendLogs()
   local mod = V.mod
   if not (mod and type(mod.postLog) == "function") then return false end
   if not (mod.manifest and mod.manifest.log_url) then return false end
-  -- Keep the remote payload in the same format as the persisted debug/log
-  -- artifact, then append the explicit-send session summary.
-  local body = logText()
-  if body ~= "" then body = body .. "\n" end
-  body = body .. stamp("session: " .. tostring(counters.jobs)
-    .. " jobs, " .. tostring(counters.errors) .. " errors")
-  local ok, handle = pcall(mod.postLog, mod, body, { format = "text" })
+  -- Identity header + the persisted-evidence text + the aggregate status
+  -- excerpt, then the explicit-send session summary.  The engine's
+  -- postLog ceiling is 512 KiB since engine PR #1382 (64 KiB before), and
+  -- a long session's ring can exceed either, so the evidence text is
+  -- trimmed -- newest lines kept -- to a budget that always leaves room
+  -- for the header, excerpt and summary.
+  local function buildBody(budget)
+    local body = headerText()
+    local text = logText()
+    if text ~= "" then
+      budget = budget - #body - 3000
+      if #text > budget then
+        local kept = {}
+        local size = 0
+        for line in text:gmatch("[^\n]+") do
+          kept[#kept + 1] = line
+          size = size + #line + 1
+        end
+        local drop = 0
+        while size > budget and drop < #kept - 1 do
+          drop = drop + 1
+          size = size - #kept[drop] - 1
+        end
+        local out = {}
+        for i = drop + 1, #kept do out[#out + 1] = kept[i] end
+        text = table.concat(out, "\n")
+        Overlay.trace("log send: trimmed %d evidence lines to fit the engine ceiling", drop)
+      end
+      body = body .. "\n" .. text
+    end
+    body = body .. "\n-- status excerpt --\n" .. snapshotText()
+    body = body .. "\n" .. stamp("session: " .. tostring(counters.jobs)
+      .. " jobs, " .. tostring(counters.errors) .. " errors")
+    return body
+  end
+  -- The engine rejects a send by returning nil plus a REASON (too large,
+  -- too many in flight, bad URL...); pcall forwards both returns, so the
+  -- reason is captured and shown instead of reading as a bare nil.
+  local body = buildBody(400000)
+  local ok, handle, reason = pcall(mod.postLog, mod, body, { format = "text" })
+  if not ok or not handle and reason and reason:find("too large") then
+    -- An engine without PR #1382 caps at 64 KiB: retry once with the
+    -- conservative budget before reporting a failure.
+    Overlay.trace("log send: payload too large for this engine; retrying trimmed")
+    body = buildBody(48000)
+    ok, handle, reason = pcall(mod.postLog, mod, body, { format = "text" })
+  end
   if not ok or not handle then
-    Overlay.note("log send failed: " .. tostring(handle))
+    Overlay.note("log send failed: %s",
+      tostring(handle or reason or "engine rejected the send"))
     return false
   end
   sendHandle = handle
+  sendAt = clock()
   Overlay.note("log sent to loghook")
   return true
 end
@@ -506,9 +632,28 @@ function Overlay.frame(dt, renderMs)
       and type(V.mod.fetch.poll) == "function" then
     local ok, st = pcall(V.mod.fetch.poll, V.mod.fetch, sendHandle)
     if ok and st and st.status ~= "pending" then
+      -- The job settled.  The engine worker does not report through the
+      -- send notice, so surface its result here: a failure is important
+      -- (stored in the support log and shown), a success is a trace.
+      if st.status == "ok" then
+        Overlay.trace("log send confirmed")
+      else
+        Overlay.note("log send failed: %s", tostring(st.err or st.status))
+      end
+      pcall(V.mod.fetch.release, V.mod.fetch, sendHandle)
+      sendHandle = nil
+    elseif ok and clock() - sendAt > 40 then
+      -- A worker that hangs (e.g. a stuck process spawn) leaves the job
+      -- pending forever; every further F8 then trips the engine's
+      -- 4-in-flight ceiling ("log send failed: nil").  Cancel and drop the
+      -- handle so the next send starts clean.
+      Overlay.note("log send timed out after %ds; cancelling",
+                   math.floor(clock() - sendAt))
+      pcall(V.mod.fetch.cancel, V.mod.fetch, sendHandle)
       pcall(V.mod.fetch.release, V.mod.fetch, sendHandle)
       sendHandle = nil
     elseif not ok then
+      Overlay.note("log send poll failed: %s", tostring(st))
       pcall(V.mod.fetch.release, V.mod.fetch, sendHandle)
       sendHandle = nil
     end
@@ -685,5 +830,15 @@ function Overlay.install()
   end)
   Overlay.note("debugger running in background -- F9 shows/hides, F10 verbosity")
 end
+
+-- The DEBUGGER option: the same visibility flag as F9, reachable from the
+-- VOXEL SETTINGS screen and the mod manager's page (Android has no F9 key,
+-- and its SELECT hold chord is gated off mobile).  Values { false, true }
+-- make the manager's schema a toggle.  main.lua's always-running tick
+-- applies it, re-asserting only when the stored value changes so it never
+-- fights a manual F9 toggle.
+local ModSetting = V.require("ModSetting")
+Overlay.setting = ModSetting.new("debugger", "DEBUGGER", { false, true },
+                                 { "OFF", "ON" })
 
 return Overlay

--- a/lib/DebugOverlay.lua
+++ b/lib/DebugOverlay.lua
@@ -578,11 +578,73 @@ function Overlay.sendLogs()
   return true
 end
 
+-- ------- log-send consent
+--
+-- F8, the SEND LOGS row and the START chord all ship the stored evidence
+-- to the manifest's log_url -- the ONE action that leaves the device.
+-- It is gated behind a one-time prompt: the first export that would
+-- send asks first, and a YES is persisted as the log_consent option so
+-- later exports never ask again. A NO sends nothing and leaves the flag
+-- unset, so the next export asks again. Engines or manifests without a
+-- log_url never prompt -- there is no send to consent to.
+
+local CONSENT_TEXT =
+  "LOGS GO TO THE\nDEVELOPER.\fSENT OVER THE\nINTERNET.\fSEND?"
+
+-- Whether this engine can send at all: engine feature #1363 (mod.postLog)
+-- plus a manifest log_url. The gate only exists where a send would
+-- actually happen, so a local-only export never asks.
+function Overlay.canSend()
+  local mod = V.mod
+  return not not (mod and type(mod.postLog) == "function"
+                  and mod.manifest and mod.manifest.log_url)
+end
+
+-- The persisted answer. Read live through the options API (ModSetting),
+-- the same store every other setting lives in, so a consent written
+-- anywhere is seen on the next read.
+function Overlay.consent()
+  return Overlay.consentSetting:get() == true
+end
+
+-- The one-time prompt, pushed as a modal over whatever the key found.
+-- The YES/NO defaults to NO -- this is opt-in -- and a YES is written
+-- to the log_consent option before the export runs, so it is asked
+-- exactly once. A NO leaves the flag unset.
+function Overlay.askConsent(g)
+  if not (g and g.stack and g.stack.push) then
+    Overlay.note("log send refused: no consent and no prompt available")
+    return false
+  end
+  local TextBox = require("src.render.TextBox")
+  g.stack:push(TextBox.new(g, CONSENT_TEXT, nil, {
+    defaultNo = true,
+    choice = function(yes)
+      if yes then
+        Overlay.consentSetting:setValue(true, g)
+        Overlay.trace("log send consented")
+        Overlay.export(g)
+      else
+        Overlay.note("log send declined")
+      end
+    end,
+  }))
+  return true
+end
+
 -- F8: export. Force the storage flush so the on-disk debug/log is
 -- current, dump every line to the console in one block (terminal users
 -- can copy it straight out), and stamp the boundary. Works even while
 -- the debugger is toggled off -- exporting is the retrieval action.
-function Overlay.export()
+--
+-- A first export that would send stops to ask first: until the player
+-- opts in, the whole export waits on the answer -- F8 / SEND LOGS is the
+-- send action, and a decline ships nothing at all.
+function Overlay.export(g)
+  g = g or game
+  if Overlay.canSend() and not Overlay.consent() then
+    return Overlay.askConsent(g)
+  end
   Overlay.runProbe()
   persist(true)
   Overlay.sendLogs()
@@ -840,5 +902,15 @@ end
 local ModSetting = V.require("ModSetting")
 Overlay.setting = ModSetting.new("debugger", "DEBUGGER", { false, true },
                                  { "OFF", "ON" })
+
+-- The log-send consent flag: false until the player answers YES to the
+-- one-time prompt in askConsent. Stored through the same options store
+-- as every other setting (the live save's options, the loader's copy
+-- mod.options:get reads, then the options file), so the answer survives
+-- restarts and New Game. It is not registered as a row anywhere -- it is
+-- the prompt's memory, not a setting to fiddle with -- but it lives in
+-- the shared store, so a future row could read it.
+Overlay.consentSetting = ModSetting.new("log_consent", "LOG CONSENT",
+                                        { false, true }, { "NO", "YES" })
 
 return Overlay

--- a/lib/HoldChord.lua
+++ b/lib/HoldChord.lua
@@ -1,0 +1,44 @@
+-- Hold-chord timers: press and hold a button for HoldChord.SECONDS to
+-- fire a one-shot chord.
+--
+-- Two chords ship:
+--
+--   select  five seconds held toggles the debug overlay -- F9's chord
+--           for touch and pads, whose SELECT buttons never arrive as a
+--           keypress.
+--
+--   start   five seconds held while the debugger is ON exports its log
+--           -- F8's chord, the retrieval half of the same switch pair.
+--
+-- Each chord is a pure timer over one boolean answer per frame: feed it
+-- `held` and it reports one crossing frame, then resets.  Releasing
+-- early aborts the count.  The timer knows nothing about the overlay or
+-- the engine: main.lua feeds `held` from the engine's Input and owns
+-- the side effect, so every chord stays one switch with its desktop key.
+
+local HoldChord = {}
+
+HoldChord.SECONDS = 5
+
+local heldFor = {}
+
+-- Advance one chord's timer.  `name` picks the chord; `dt` is the frame
+-- time; `held` is whether the button is down this frame.  Returns true
+-- on exactly the frame the hold crosses HoldChord.SECONDS, then resets
+-- so a continued hold cannot retrigger.
+function HoldChord.update(name, dt, held)
+  local acc = heldFor[name] or 0
+  if held then
+    acc = acc + (dt or 0)
+    if acc >= HoldChord.SECONDS then
+      heldFor[name] = nil
+      return true
+    end
+  else
+    acc = 0
+  end
+  heldFor[name] = acc
+  return false
+end
+
+return HoldChord

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -449,7 +449,15 @@ local RAW_FORMAT = 1
 local COMPRESSED_FORMAT = 2
 local LZ4_CODEC = 1
 local ZSTD_CODEC = 2
-local CODEC_NAMES = { [LZ4_CODEC] = "lz4", [ZSTD_CODEC] = "zstd" }
+local ZLIB_CODEC = 3
+-- zstd where the runtime has it (desktop LÖVE), else zlib/deflate, else
+-- lz4. The engine's table-storage writes serialize byte values as escaped
+-- Lua source (~4-6x the payload), so the payload size directly drives the
+-- write+verify stall: zlib's better ratio on quantized mesh data is worth
+-- its slower compress here (the compress is one bounded call, the write it
+-- saves is seconds).
+local CODEC_NAMES = { [LZ4_CODEC] = "lz4", [ZSTD_CODEC] = "zstd",
+                      [ZLIB_CODEC] = "zlib" }
 local MAX_PAYLOAD = 512 * 1024 * 1024
 
 -- ffi is sandbox-banned and this engine's love.data ByteData carries no
@@ -564,6 +572,11 @@ local function packPayload(fp, body)
     local ok, packed = pcall(data.compress, "string", "zstd", body)
     if ok and type(packed) == "string" and #packed < #body then
       return header(fp, COMPRESSED_FORMAT, #body, #packed, 0, ZSTD_CODEC)
+             .. packed
+    end
+    ok, packed = pcall(data.compress, "string", "zlib", body)
+    if ok and type(packed) == "string" and #packed < #body then
+      return header(fp, COMPRESSED_FORMAT, #body, #packed, 0, ZLIB_CODEC)
              .. packed
     end
     ok, packed = pcall(data.compress, "string", "lz4", body)
@@ -870,31 +883,6 @@ local function repackRaw(key, mkey, fp, body, meta)
   end
 end
 
-local function payloadFingerprint(key, mkey, fp, kind)
-  local ok, s = pcall(readBytes, key)
-  if not ok or not s then return nil end
-  local got, off, meta = parseHeader(s)
-  if not got then return nil end
-  if got ~= fp then return nil end
-  local body = unpackPayload(s, off, meta)
-  if not body then return nil end
-  if kind ~= "aux" then
-    return decodeQuant(body) and got or nil
-  end
-  local grass = decodeIndexed(body)
-  if not grass then return nil end
-  local flowerPos = 4 + grass.n * 24 + 4 + grass.m * 4
-  local flowers = decodeIndexed(body:sub(1 + flowerPos))
-  if not flowers then return nil end
-  local figurePos = flowerPos + 4 + flowers.n * 24 + 4 + flowers.m * 4
-  return decodeFigures(body:sub(1 + figurePos)) and got or nil
-end
-
-local function safeValidPayload(key, mkey, fp, kind)
-  local ok, valid = pcall(payloadFingerprint, key, mkey, fp, kind)
-  return ok and valid
-end
-
 -- A meta record's fingerprint, validated against the live identity
 -- prefix for the job. nil when missing or stale.
 local function metaFingerprint(mkey, prefix)
@@ -909,6 +897,28 @@ end
 local function safeMetaFingerprint(mkey, prefix)
   local ok, got = pcall(metaFingerprint, mkey, prefix)
   return ok and got or nil
+end
+
+-- A payload is VERIFIED without decoding it. parseHeader bounds the body
+-- (magic, format, fingerprint, packed length against the stored bytes),
+-- the meta record is the write's commit marker, and the engine's storage
+-- write already round-tripped the bytes (stage tmp, verify decode, write
+-- main, verify again). The full decodeQuant was pure-Lua over every
+-- vertex and ran OUTSIDE the build coroutine -- Budget.check() is a no-op
+-- there -- so verifying one job's terrain+water this way was one of the
+-- multi-second main-thread stalls during the prebuild. Payloads are
+-- re-validated the moment a map actually loads (loadTerrain/loadWater).
+local function payloadShape(key, mkey, fp)
+  local ok, s = pcall(readBytes, key)
+  if not ok or not s then return nil end
+  local got = parseHeader(s)
+  if not got or got ~= fp then return nil end
+  return safeMetaFingerprint(mkey, fp) and got or nil
+end
+
+local function safeValidPayload(key, mkey, fp)
+  local ok, valid = pcall(payloadShape, key, mkey, fp)
+  return ok and valid
 end
 
 local function updateCompression(records)
@@ -964,9 +974,12 @@ function MeshCache.jobRecord(map, slot)
   }
 end
 
--- A record whose three payload metas all exist under the live identity.
--- NOTE the record carries META keys (the boot scan's bounded reads);
--- payload bytes are validated when a map actually loads.
+-- A record whose terrain and water payload metas exist under the live
+-- identity. The aux meta is OPTIONAL: a job whose aux save failed still
+-- has complete terrain/water (fillAux builds the aux live), and treating
+-- it as required made a stale-aux job fail the boot scan and re-trigger a
+-- full rebuild every launch. NOTE the record carries META keys (the boot
+-- scan's bounded reads); payload bytes are validated when a map loads.
 local function scanJob(job)
   local map = { id = job.id }
   local slot = tostring(job.slot)
@@ -976,17 +989,24 @@ local function scanJob(job)
   local waterMeta = safeMetaFingerprint(
     metaKey(map, slot, "water"),
     identity() .. "|" .. tostring(job.id) .. "|" .. slot .. "Water|")
+  if not (terrainMeta and waterMeta) then return nil end
   local auxMeta = safeMetaFingerprint(
     metaKey(map, slot, "aux"),
     identity() .. "|" .. tostring(job.id) .. "|" .. slot .. "Aux|")
-  if not (terrainMeta and waterMeta and auxMeta) then return nil end
   return { key = tostring(job.id) .. "/" .. slot,
            terrain = metaKey(map, slot, "terrain"),
            terrainFp = terrainMeta.fp, water = metaKey(map, slot, "water"),
-           waterFp = waterMeta.fp, aux = metaKey(map, slot, "aux"),
-           auxFp = auxMeta.fp }
+           waterFp = waterMeta.fp,
+           aux = auxMeta and metaKey(map, slot, "aux") or nil,
+           auxFp = auxMeta and auxMeta.fp or nil }
 end
 
+-- A job's critical payloads are terrain + water: the aux (grass/flowers/
+-- figures) is optional because fillAux already falls back to building it
+-- live when the cache has none. Requiring all three made a single aux
+-- write failure fail the job -- and CachePrebuild then aborted the whole
+-- build -- so a platform whose aux save failed rebuilt every job each
+-- boot. Terrain/water remain mandatory: without them the map has nothing.
 function MeshCache.verifyJob(map, slot)
   if not MeshCache.available() then return false end
   local record = MeshCache.jobRecord(map, slot)
@@ -995,8 +1015,6 @@ function MeshCache.verifyJob(map, slot)
                           record.terrain, record.terrainFp, "mesh")
      and safeValidPayload(payloadKey(mapSlot, slot, "water"),
                           record.water, record.waterFp, "mesh")
-     and safeValidPayload(payloadKey(mapSlot, slot, "aux"),
-                          record.aux, record.auxFp, "aux")
 end
 
 -- --------------------------------------------------------------- manifest
@@ -1082,7 +1100,8 @@ function MeshCache.ready(jobs)
     local ok = record ~= nil
            and safeMetaFingerprint(record.terrain, record.terrainFp) ~= nil
            and safeMetaFingerprint(record.water, record.waterFp) ~= nil
-           and safeMetaFingerprint(record.aux, record.auxFp) ~= nil
+           and (record.aux == nil
+                or safeMetaFingerprint(record.aux, record.auxFp) ~= nil)
     if ok then done = done + 1 end
   end
   if done == #jobs then
@@ -1269,6 +1288,7 @@ function MeshCache.loadTerrain(map, slot)
       Overlay.trace("cache hit terrain %s/%s (%dms, %d verts)",
                    tostring(map.id), tostring(slot), ms, mesh.n or 0)
       if ms and ms > 250 then
+        Overlay.count("slowLoads")
         Overlay.error("SLOW load terrain %s/%s: %dms", tostring(map.id),
                      tostring(slot), ms)
       end

--- a/lib/PixelCanvas.lua
+++ b/lib/PixelCanvas.lua
@@ -3,7 +3,10 @@ local V = ...
 local PixelCanvas = {}
 
 function PixelCanvas.new(w, h)
-  return pcall(love.graphics.newCanvas, w, h, { dpiscale = 1 })
+  local ok, canvas = pcall(love.graphics.newCanvas, w, h,
+                           { dpiscale = 1 })
+  if ok then return canvas ~= nil, canvas, canvas and nil or "newCanvas returned nil" end
+  return false, nil, tostring(canvas)
 end
 
 return PixelCanvas

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -156,7 +156,7 @@ ShadowMap.SLOPE = 3.1
 ShadowMap.slack = ShadowMap.BIAS
 
 local SHADER = [[
-  varying float vDepth;
+  varying LOVE_HIGHP_OR_MEDIUMP float vDepth;
 #ifdef VERTEX
   uniform mat4 lightVP;
   uniform mat4 model;
@@ -174,8 +174,14 @@ local SHADER = [[
   }
 #endif
 #ifdef PIXEL
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+  precision highp float;
+#endif
+#endif
   uniform float sprite;   // 1 while the CAST is being drawn; see ShadowMap.sprites
-  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+  vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
+              EFFECT_PREC vec2 sc) {
     // the same alpha discard the main pass uses: a sprite card casts its
     // silhouette, not its 16x16 bounding box
     if (Texel(tex, tc).a < 0.5) discard;
@@ -189,12 +195,37 @@ local SHADER = [[
 #endif
 ]]
 
-ShadowMap._source = function() return SHADER end   -- named for the suite
+-- Match the scene and water shader compatibility path. LOVE's wrapper
+-- forward-declares effect() using its stage default precision, while some
+-- mobile compilers treat an implicit-precision definition as a different
+-- overload after this fragment asks for highp. Try the explicit mediump
+-- prototype first, then the stage-default spelling.
+local function source(bare)
+  return (bare and "#define EFFECT_PREC\n"
+               or "#define EFFECT_PREC mediump\n") .. SHADER
+end
+
+ShadowMap._source = source                 -- named for the suite
 
 local shader = nil            -- nil = untried, false = unavailable
+local shaderError = nil       -- retained for mobile compiler diagnostics
+local shaderPrecision = nil   -- "mediump" or "default" when compilation succeeds
+local shaderFallbackError = nil -- pinned prototype error before a retry
 local canvas = nil            -- nil = untried, false = unavailable
+local canvasError = nil       -- retained when PixelCanvas cannot allocate
 local canvasRes = 0           -- the edge `canvas` was made at
 local spriteCanvas = nil      -- the CAST layer: sprites only (see below)
+local spriteCanvasError = nil
+-- GLES devices can allocate a colour canvas while rejecting LOVE's implicit
+-- transient depth attachment. Keep an explicit depth canvas as the primary
+-- target, with the implicit form as a compatibility fallback. The two colour
+-- layers are never bound at the same time, so one depth canvas can be reused.
+local depthCanvas = nil       -- nil = untried, false = unavailable
+local depthCanvasRes = 0
+local depthFailures = {}
+local depthBinding = nil      -- "explicit", "internal", or "unavailable"
+local depthError = nil
+local depthFallbackError = nil
 local blank = nil             -- 1x1 stand-in so the sampler is never unbound
 local drawing = false         -- world layer open (beginWorld)
 local drawingSprites = false  -- sprite layer open (beginSprites)
@@ -203,6 +234,14 @@ local spritesReady = false
 local lastSig = nil
 local lastSpriteSig = nil
 local prevBlend, prevAlphaMode = nil, nil
+local activePass = nil        -- "world" or "sprite"
+local lastPass = nil
+local lastPassError = nil
+local passCounts = { begins = 0, finishes = 0, aborts = 0 }
+
+-- The engine's scene renderer uses the same preference order. Depth formats
+-- are optional in GLES; probing the actual canvas is the capability test.
+local DEPTH_FORMATS = { "depth24", "depth24stencil8", "depth32f", "depth16" }
 
 local IDENTITY = Mat4.identity()
 
@@ -247,10 +286,102 @@ end
 
 local function getShader()
   if shader == nil then
-    local ok, sh = pcall(love.graphics.newShader, SHADER)
-    shader = (ok and sh) or false
+    local function compile(bare)
+      local ok, sh = pcall(love.graphics.newShader, source(bare))
+      if ok and sh then return sh end
+      return nil, ok and "newShader returned nil" or tostring(sh)
+    end
+    local sh, err = compile(false)
+    if sh then
+      shaderPrecision = "mediump"
+    else
+      local retry, retryErr = compile(true)
+      if retry then
+        sh = retry
+        shaderPrecision = "default"
+        shaderFallbackError = err
+      else
+        shaderError = "mediump: " .. tostring(err)
+                       .. "; default: " .. tostring(retryErr)
+      end
+    end
+    shader = sh or false
   end
   return shader or nil
+end
+
+local function releaseDepthCanvas()
+  if depthCanvas and depthCanvas.release then
+    pcall(depthCanvas.release, depthCanvas)
+  end
+  depthCanvas = nil
+  depthCanvasRes = 0
+end
+
+-- Allocate a real depth attachment when the backend supports one. This is
+-- deliberately separate from the packed colour map: the colour stores the
+-- light-space distance, while the depth attachment makes nearer casters win
+-- when the map is filled.
+local function getDepthCanvas(res)
+  if depthCanvas == false and depthCanvasRes == res then return nil end
+  if depthCanvas and depthCanvasRes == res then return depthCanvas end
+  releaseDepthCanvas()
+  depthFailures = {}
+  if not (love and love.graphics and love.graphics.newCanvas) then
+    depthCanvas = false
+    depthCanvasRes = res
+    depthFailures[1] = { format = "all", error = "newCanvas unavailable" }
+    return nil
+  end
+  for _, format in ipairs(DEPTH_FORMATS) do
+    local ok, made = pcall(love.graphics.newCanvas, res, res,
+                           { format = format })
+    if ok and made then
+      depthCanvas = made
+      depthCanvasRes = res
+      pcall(made.setFilter, made, "nearest", "nearest")
+      pcall(made.setWrap, made, "clamp", "clamp")
+      return made
+    end
+    depthFailures[#depthFailures + 1] = {
+      format = format,
+      error = ok and "newCanvas returned nil" or tostring(made),
+    }
+  end
+  depthCanvas = false
+  depthCanvasRes = res
+  return nil
+end
+
+-- Bind the packed colour map plus a depth target. Prefer the explicit depth
+-- canvas because it is the path already proven by Voxel3D on mobile. If a
+-- driver rejects that attachment, try LOVE's internal depth buffer before
+-- declaring the advanced shadow pass unavailable.
+local function bindShadowTarget(color)
+  depthFallbackError = nil
+  if depthCanvas and depthCanvas ~= false then
+    local ok, err = pcall(love.graphics.setCanvas,
+                          { color, depthstencil = depthCanvas })
+    if ok then
+      depthBinding = "explicit"
+      depthError = nil
+      return true
+    end
+    depthFallbackError = tostring(err)
+    releaseDepthCanvas()
+    depthCanvas = false
+  end
+
+  local ok, err = pcall(love.graphics.setCanvas, { color, depth = true })
+  if ok then
+    depthBinding = "internal"
+    depthError = nil
+    return true
+  end
+  pcall(love.graphics.setCanvas)
+  depthBinding = "unavailable"
+  depthError = tostring(err)
+  return false, depthError
 end
 
 -- The map canvas at edge `res`, rebuilt when the rung changes (a zoom
@@ -269,12 +400,17 @@ end
 -- nothing closer along the sun ray sits in EITHER layer.
 local function getCanvas(res)
   if canvas == false then return nil end
-  if canvas and canvasRes == res then return canvas end
-  local ok, c = V.require("PixelCanvas").new(res, res)
+  if canvas and canvasRes == res then
+    getDepthCanvas(res)
+    return canvas
+  end
+  local ok, c, err = V.require("PixelCanvas").new(res, res)
   if not (ok and c) then
+    canvasError = err or "newCanvas returned nil"
     canvas = false
     return nil
   end
+  canvasError = nil
   -- nearest: the 2x2 filter in the main pass wants raw texels, and a
   -- linearly blended PACKED depth is not a depth at all
   c:setFilter("nearest", "nearest")
@@ -286,18 +422,22 @@ local function getCanvas(res)
     pcall(spriteCanvas.release, spriteCanvas)
   end
   if ShadowMap.SPRITE_LAYER then
-    local okS, sc = V.require("PixelCanvas").new(res, res)
+    local okS, sc, errS = V.require("PixelCanvas").new(res, res)
     if okS and sc then
+      spriteCanvasError = nil
       sc:setFilter("nearest", "nearest")
       pcall(sc.setWrap, sc, "clamp", "clamp")
       spriteCanvas = sc
     else
+      spriteCanvasError = errS or "newCanvas returned nil"
       spriteCanvas = false
     end
   else
+    spriteCanvasError = nil
     spriteCanvas = false
   end
   spritesReady = false
+  getDepthCanvas(res)
   return canvas
 end
 
@@ -327,7 +467,7 @@ local unavailable = nil    -- why available() last answered false
 -- player guessing.
 function ShadowMap.available()
   if unavailable then return false end
-  if not (love.graphics and love.graphics.newCanvas
+  if not (love and love.graphics and love.graphics.newCanvas
           and love.graphics.setDepthMode) then
     unavailable = "no canvas/depth-mode graphics API"
     return false
@@ -336,10 +476,12 @@ function ShadowMap.available()
   -- one this frame actually wants
   if getShader() == nil then
     unavailable = "the shadow shader did not compile"
+                    .. (shaderError and (": " .. shaderError) or "")
     return false
   end
   if getCanvas(ShadowMap.SIZES[1]) == nil then
     unavailable = "the shadow canvas could not be allocated"
+                    .. (canvasError and (": " .. canvasError) or "")
     return false
   end
   return true
@@ -350,6 +492,40 @@ end
 function ShadowMap.unavailableReason()
   if ShadowMap.available() then return nil end
   return unavailable
+end
+
+-- Data-only capability state for the debugger. `available()` remains the
+-- single gate used by rendering; this report adds the compiler/allocation
+-- detail that a boolean cannot carry into a support log.
+function ShadowMap.diagnostics()
+  local ok = ShadowMap.available()
+  return {
+    available = ok,
+    reason = ok and "ready" or unavailable,
+    shaderError = shaderError,
+    shaderPrecision = shaderPrecision,
+    shaderFallbackError = shaderFallbackError,
+    canvasError = canvasError,
+    spriteCanvasError = spriteCanvasError,
+    depth = {
+      formats = DEPTH_FORMATS,
+      failures = depthFailures,
+      binding = depthBinding,
+      error = depthError,
+      fallbackError = depthFallbackError,
+    },
+    resolution = ShadowMap.res,
+    worldReady = ready,
+    spriteReady = spritesReady,
+    activePass = activePass,
+    lastPass = lastPass,
+    lastFailure = ShadowMap.beginFailure or lastPassError,
+    passCounts = {
+      begins = passCounts.begins,
+      finishes = passCounts.finishes,
+      aborts = passCounts.aborts,
+    },
+  }
 end
 
 -- The map to sample, or the blank stand-in. Never nil once the main pass
@@ -664,18 +840,21 @@ end
 -- the default is the WORLD layer (terrain, water, flowers, figures).
 -- The two layers share the same fitted box, so only a world begin
 -- re-fits; a sprite begin reuses the current fit.
--- Why begin() last returned false (transient -- cleared by the next
--- successful begin), for diagnostics. Policy gates (the sprite layer being
--- off on a rung) are not failures and leave this alone.
+-- Why begin() last returned false, for diagnostics. Policy gates (the sprite
+-- layer being off on a rung) are not failures and leave this alone.
 ShadowMap.beginFailure = nil
 
 function ShadowMap.begin(cx, cy, vw, vh, sprites)
+  local passName = sprites and "sprite" or "world"
+  activePass = nil
+  ShadowMap.beginFailure = nil
   if sprites and (not ShadowMap.SPRITE_LAYER or not actorLayerActive) then
     return false
   end
   local sh = getShader()
   if not sh then
     ShadowMap.beginFailure = "the shadow shader did not compile"
+    lastPass, lastPassError = passName, ShadowMap.beginFailure
     return false
   end
   if not sprites then
@@ -685,10 +864,12 @@ function ShadowMap.begin(cx, cy, vw, vh, sprites)
     -- canvas would be a 1024 map wearing a 1536 fit's snap and bias.
     if not fit(cx, cy, vw, vh) then
       ShadowMap.beginFailure = "the light frustum is degenerate this frame"
+      lastPass, lastPassError = passName, ShadowMap.beginFailure
       return false
     end
     if getCanvas(ShadowMap.res) == nil then
       ShadowMap.beginFailure = "the shadow canvas could not be allocated"
+      lastPass, lastPassError = passName, ShadowMap.beginFailure
       return false
     end
   end
@@ -696,28 +877,43 @@ function ShadowMap.begin(cx, cy, vw, vh, sprites)
   if not c or c == false then
     ShadowMap.beginFailure = sprites and "the sprite shadow canvas is unavailable"
                              or "the shadow canvas is unavailable"
+    lastPass, lastPassError = passName, ShadowMap.beginFailure
     return false
   end
-  local ok = pcall(love.graphics.setCanvas, { c, depth = true })
+  local ok, bindErr = bindShadowTarget(c)
   if not ok then
-    pcall(love.graphics.setCanvas)
-    ShadowMap.beginFailure = "the shadow canvas could not be bound"
+    ShadowMap.beginFailure = "the shadow depth target could not be bound"
+                         .. (bindErr and (": " .. bindErr) or "")
+    unavailable = ShadowMap.beginFailure
+    lastPass, lastPassError = passName, ShadowMap.beginFailure
     return false
   end
-  prevBlend, prevAlphaMode = love.graphics.getBlendMode()
-  -- white clears to depth 1 + 1/255, past the far plane: a texel nothing
-  -- was drawn into can never shadow anything
-  love.graphics.clear(1, 1, 0, 1, true, true)
-  love.graphics.setDepthMode("lequal", true)
-  love.graphics.setMeshCullMode("none")
-  -- replace, not alpha blend: these are packed numbers, not colors
-  love.graphics.setBlendMode("replace", "premultiplied")
-  love.graphics.setShader(sh)
-  love.graphics.setColor(1, 1, 1, 1)
-  pcall(sh.send, sh, "lightVP", "row", ShadowMap.clipVP)
-  -- the world until a cast pass says otherwise, reset per pass so one that
-  -- forgot to put it back cannot leak into the next map's terrain
-  pcall(sh.send, sh, "sprite", 0)
+  local setupOk, setupErr = pcall(function()
+    prevBlend, prevAlphaMode = love.graphics.getBlendMode()
+    -- white clears to depth 1 + 1/255, past the far plane: a texel nothing
+    -- was drawn into can never shadow anything
+    love.graphics.clear(1, 1, 0, 1, true, true)
+    love.graphics.setDepthMode("lequal", true)
+    love.graphics.setMeshCullMode("none")
+    -- replace, not alpha blend: these are packed numbers, not colors
+    love.graphics.setBlendMode("replace", "premultiplied")
+    love.graphics.setShader(sh)
+    love.graphics.setColor(1, 1, 1, 1)
+    pcall(sh.send, sh, "lightVP", "row", ShadowMap.clipVP)
+    -- the world until a cast pass says otherwise, reset per pass so one that
+    -- forgot to put it back cannot leak into the next map's terrain
+    pcall(sh.send, sh, "sprite", 0)
+  end)
+  if not setupOk then
+    pcall(love.graphics.setShader)
+    pcall(love.graphics.setDepthMode)
+    pcall(love.graphics.setCanvas)
+    pcall(love.graphics.setBlendMode, prevBlend or "alpha", prevAlphaMode)
+    pcall(love.graphics.setColor, 1, 1, 1, 1)
+    ShadowMap.beginFailure = "shadow pass setup failed: " .. tostring(setupErr)
+    lastPass, lastPassError = passName, ShadowMap.beginFailure
+    return false
+  end
   if sprites then
     drawingSprites = true
     spritesReady = false
@@ -725,7 +921,10 @@ function ShadowMap.begin(cx, cy, vw, vh, sprites)
     drawing = true
     ready = false
   end
-  ShadowMap.beginFailure = nil
+  activePass = passName
+  lastPass = passName
+  lastPassError = nil
+  passCounts.begins = passCounts.begins + 1
   return true
 end
 
@@ -781,17 +980,33 @@ function ShadowMap.finish(sig, sprites)
     lastSig = sig
     ready = true
   end
+  activePass = nil
+  lastPass = sprites and "sprite" or "world"
+  lastPassError = nil
+  passCounts.finishes = passCounts.finishes + 1
 end
 
 -- Unconditionally restore the GL state a pass changes, after an error
 -- anywhere inside begin..finish. A pass that dies mid-draw leaves the
 -- shadow canvas bound, and every later frame renders the WORLD into that
 -- 1024px offscreen map -- a black screen, exactly the Mediatek report.
--- Callers pcall-wrap their pass and call this from the error handler;
--- harmless (and cheap) when no pass is open.
-function ShadowMap.abort()
-  drawing, drawingSprites = false, false
-  ready, spritesReady = false, false
+-- Callers pcall-wrap their pass and call this from the error handler. Only the
+-- active layer is invalidated: a failed actor pass must not erase a world map
+-- that already finished successfully.
+function ShadowMap.abort(sprites, err)
+  local passName = sprites == nil and activePass
+                 or (sprites and "sprite" or "world")
+  if passName == "sprite" then
+    drawingSprites = false
+    spritesReady = false
+  elseif passName == "world" then
+    drawing = false
+    ready = false
+  end
+  activePass = nil
+  lastPass = passName or lastPass
+  lastPassError = tostring(err or ShadowMap.beginFailure or "shadow pass aborted")
+  passCounts.aborts = passCounts.aborts + 1
   pcall(love.graphics.setShader)
   pcall(love.graphics.setDepthMode)
   pcall(love.graphics.setCanvas)
@@ -802,10 +1017,26 @@ end
 -- Drop the GPU objects (window resize, hot reload).
 function ShadowMap.invalidate()
   canvas, canvasRes, blank = nil, 0, nil
+  releaseDepthCanvas()
+  depthCanvas = nil
+  depthFailures = {}
+  depthBinding = nil
+  depthError = nil
+  depthFallbackError = nil
+  canvasError = nil
+  spriteCanvasError = nil
+  shaderError = nil
+  shaderPrecision = nil
+  shaderFallbackError = nil
+  shader = nil
   spriteCanvas = nil
   drawing, drawingSprites = false, false
   ready, spritesReady = false, false
   lastSig, lastSpriteSig = nil, nil
+  activePass = nil
+  lastPass = nil
+  lastPassError = nil
+  passCounts = { begins = 0, finishes = 0, aborts = 0 }
   unavailable = nil
   ShadowMap.beginFailure = nil
 end

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -71,7 +71,7 @@ Voxel3D.FACE_SHADE = {
 
 local SHADER = [[
   varying float vShade;
-  varying vec3 vSun;          // this fragment's place in the sun's view
+  varying LOVE_HIGHP_OR_MEDIUMP vec3 vSun; // this fragment's place in the sun's view
   varying float vFog;         // how deep into the map's haze it stands
 #ifdef VOXEL_GRID
   // model space, one unit per voxel -- see VoxelGrid. Precision matters
@@ -153,6 +153,11 @@ local SHADER = [[
   }
 #endif
 #ifdef PIXEL
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+  precision highp float;
+#endif
+#endif
   uniform Image sunMap;
   uniform Image sunMap2;      // the CAST layer: sprites only (see ShadowMap)
   uniform float sunDark;      // how far into black a shadow goes; 0 = off
@@ -253,7 +258,8 @@ local SHADER = [[
   uniform float glassGlint;   // and its strength: 0 while standing still
   uniform float glassOn;      // 0 for sprite-sheet draws (see Voxel3D.glass)
 
-  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+  vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
+              EFFECT_PREC vec2 sc) {
     vec4 p = Texel(tex, tc);
     // sprite sheets key GB OBJ color 0 to alpha 0; discarding rather than
     // blending keeps those texels out of the depth buffer, so a model never
@@ -315,13 +321,36 @@ local SHADER = [[
 #endif
 ]]
 
+-- LOVE's wrapper forward-declares effect() using its stage default precision.
+-- Some mobile compilers treat a definition whose implicit parameter precision
+-- differs from that prototype as a second overload and reject the shader.
+-- Keep the proven Water.lua two-variant seam: pin the effect parameters to
+-- mediump first, then retry with no qualifier for runtimes whose prototype
+-- uses the default instead.
+local function source(grid, bare)
+  local head = ""
+  if grid then head = head .. "#define VOXEL_GRID 1\n" end
+  head = head .. (bare and "#define EFFECT_PREC\n"
+                       or "#define EFFECT_PREC mediump\n")
+  return head .. SHADER
+end
+
+Voxel3D._source = source                 -- named for the suite
+
 -- Two compilations of SHADER: the plain scene, and the same thing with the
 -- voxel wireframe compiled in. The wireframe needs shader derivatives
 -- (fwidth), the one piece of this a driver can refuse, so it is a separate
 -- build rather than a branch -- a refusal costs the grid and nothing else.
--- Each entry is nil = untried, false = unavailable.
+-- Each entry is nil = untried, false = unavailable. The companion error is
+-- retained because a boolean hardware gate is not enough to diagnose a
+-- mobile shader regression after the engine falls back to 2D.
 local shaders = { [false] = nil, [true] = nil }
+local shaderErrors = { [false] = nil, [true] = nil }
+local shaderPrecision = { [false] = nil, [true] = nil }
+local shaderFallbackErrors = { [false] = nil, [true] = nil }
 local activeShader = nil      -- the variant this pass bound
+local depthFailures = {}
+Voxel3D.beginFailure = nil
 
 -- Scene canvases, one per NAMED SLOT. There are exactly two callers and
 -- they want different sizes -- the free-roam pass renders at the window's
@@ -356,10 +385,15 @@ local DEPTH_FORMATS = { "depth24", "depth24stencil8", "depth32f", "depth16" }
 local function newDepth(w, h)
   if not (love.graphics and love.graphics.newCanvas) then return nil end
   local c = nil
+  depthFailures = {}
   for _, format in ipairs(DEPTH_FORMATS) do
     local ok, made = pcall(love.graphics.newCanvas, w, h,
                            { format = format, readable = true })
     if ok and made then c = made break end
+    depthFailures[#depthFailures + 1] = {
+      format = format,
+      error = ok and "newCanvas returned nil" or tostring(made),
+    }
   end
   if not c then return nil end
   -- nearest: a depth is a distance, and a blend of two of them is a
@@ -413,9 +447,26 @@ function Voxel3D.shader(grid)
     if grid and not derivativesOK() then
       shaders[grid] = false
     else
-      local src = grid and ("#define VOXEL_GRID 1\n" .. SHADER) or SHADER
-      local ok, sh = pcall(love.graphics.newShader, src)
-      shaders[grid] = ok and sh or false
+      local function compile(bare)
+        local ok, sh = pcall(love.graphics.newShader, source(grid, bare))
+        if ok and sh then return sh end
+        return nil, ok and "newShader returned nil" or tostring(sh)
+      end
+      local sh, err = compile(false)
+      if sh then
+        shaderPrecision[grid] = "mediump"
+      else
+        local retry, retryErr = compile(true)
+        if retry then
+          sh = retry
+          shaderPrecision[grid] = "default"
+          shaderFallbackErrors[grid] = err
+        else
+          shaderErrors[grid] = "mediump: " .. tostring(err)
+                               .. "; default: " .. tostring(retryErr)
+        end
+      end
+      shaders[grid] = sh or false
     end
   end
   return shaders[grid] or nil
@@ -425,11 +476,53 @@ end
 -- love.graphics), without shader support, or where a depth canvas cannot be
 -- created -- every caller treats that as "stay on the 2D path".
 function Voxel3D.available()
-  if not (love.graphics and love.graphics.newCanvas
-          and love.graphics.setDepthMode) then
-    return false
+  return Voxel3D.diagnostics().available
+end
+
+-- A data-only capability report for the debugger and support exports. The
+-- probe intentionally compiles the plain scene shader, but does not allocate
+-- a full-size scene target; beginScene records allocation/bind failures when
+-- the first real dimensions are known.
+function Voxel3D.diagnostics()
+  local g = love and love.graphics
+  local out = {
+    available = false,
+    reason = nil,
+    shader = { plain = shaders[false] ~= false and shaders[false] ~= nil,
+               grid = shaders[true] ~= false and shaders[true] ~= nil },
+    shaderErrors = { plain = shaderErrors[false], grid = shaderErrors[true] },
+    shaderPrecision = { plain = shaderPrecision[false],
+                        grid = shaderPrecision[true] },
+    shaderFallbackErrors = { plain = shaderFallbackErrors[false],
+                             grid = shaderFallbackErrors[true] },
+    depth = { formats = DEPTH_FORMATS, failures = depthFailures },
+    lastFailure = Voxel3D.beginFailure,
+  }
+  if not g then
+    out.reason = "no graphics module"
+    return out
   end
-  return Voxel3D.shader() ~= nil
+  if not g.newCanvas then
+    out.reason = "missing graphics API: newCanvas"
+    return out
+  end
+  if not g.setDepthMode then
+    out.reason = "missing graphics API: setDepthMode"
+    return out
+  end
+  if not g.newShader then
+    out.reason = "missing graphics API: newShader"
+    return out
+  end
+  local sh = Voxel3D.shader()
+  if not sh then
+    out.reason = "scene_shader_compile"
+    out.error = shaderErrors[false] or "plain scene shader unavailable"
+    return out
+  end
+  out.available = true
+  out.reason = "ready"
+  return out
 end
 
 -- Build a mesh in the shared format. `verts` is the LOVE vertex list and
@@ -866,6 +959,7 @@ end
 -- `slot` names which cached canvas to render into (see `slots` above);
 -- omitted is the free-roam world pass.
 function Voxel3D.beginScene(w, h, cx, cy, vw, vh, sky, slot)
+  Voxel3D.beginFailure = nil
   -- the wireframe variant when the player has it on AND it built; either
   -- answer falls through to the plain scene rather than to no scene
   local grid = VoxelGrid.enabled()
@@ -873,12 +967,19 @@ function Voxel3D.beginScene(w, h, cx, cy, vw, vh, sky, slot)
   if not sh then
     grid, sh = false, Voxel3D.shader()
   end
-  if not sh then return false end
+  if not sh then
+    Voxel3D.beginFailure = shaderErrors[false]
+                           or "plain scene shader unavailable"
+    return false
+  end
   local name = slot or "world"
   local slotHeld = slots[name]
   if not (slotHeld and slotHeld.w == w and slotHeld.h == h) then
-    local ok, c = PixelCanvas.new(w, h)
-    if not ok then return false end
+    local ok, c, err = PixelCanvas.new(w, h)
+    if not ok then
+      Voxel3D.beginFailure = err or "scene color canvas allocation failed"
+      return false
+    end
     c:setFilter("nearest", "nearest")
     if slotHeld then releaseSlot(slotHeld) end
     -- the depth canvas is sized with its colour, so a window resize
@@ -900,6 +1001,9 @@ function Voxel3D.beginScene(w, h, cx, cy, vw, vh, sky, slot)
   end
   if not ok then
     pcall(love.graphics.setCanvas)
+    Voxel3D.beginFailure = held.depth
+                           and "scene depth canvas could not bind"
+                           or "scene canvas/depth target could not bind"
     return false
   end
   -- Ahead of the clear, because the sky's bands are placed off the ground
@@ -1498,6 +1602,12 @@ function Voxel3D.invalidate()
   end
   canvas, canvasW, canvasH = nil, 0, 0
   held = nil
+  shaders[false], shaders[true] = nil, nil
+  shaderErrors[false], shaderErrors[true] = nil, nil
+  shaderPrecision[false], shaderPrecision[true] = nil, nil
+  shaderFallbackErrors[false], shaderFallbackErrors[true] = nil, nil
+  depthFailures = {}
+  Voxel3D.beginFailure = nil
   -- the VR sky's disc mesh belongs to this context like the canvases do
   if discMesh and discMesh.release then pcall(discMesh.release, discMesh) end
   discMesh = nil

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -922,7 +922,7 @@ local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
       ShadowMap.finish(worldSig, false)
     end)
     if not ok then
-      ShadowMap.abort()
+      ShadowMap.abort(false, err)
       pcall(print, "[PotatoVoxel] shadow world pass aborted: " .. tostring(err))
     end
   end
@@ -930,7 +930,7 @@ local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
   -- sprite layer: posed characters + battle cards, snugged and marked as
   -- the cast so water declines them. Only when a sprite actually moved.
   if spriteLayer and (spriteStale or worldStale) then
-    local ok = pcall(function()
+    local ok, err = pcall(function()
       if not ShadowMap.begin(cx, cy, vw, vh, true) then return end
       ShadowMap.sprites(true)
       for _, p in ipairs(posed) do
@@ -958,7 +958,10 @@ local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
       ShadowMap.sprites(false)
       ShadowMap.finish(spriteSig, true)
     end)
-    if not ok then ShadowMap.abort() end
+    if not ok then
+      ShadowMap.abort(true, err)
+      pcall(print, "[PotatoVoxel] shadow sprite pass aborted: " .. tostring(err))
+    end
   end
 end
 

--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -409,7 +409,7 @@ Water.EDGE_FADE = 0.14         -- reflection eased off over this much of the fra
 -- stage applies and therefore lands in the same place the geometry did.
 local SHADER_SRC = [[
 varying float vShade;
-varying vec3 vSun;
+varying LOVE_HIGHP_OR_MEDIUMP vec3 vSun;
 // World position, as drawn -- and a varying that cannot ride GLSL ES's
 // mediump fragment default: everything below floors it into columns and
 // marches it through the frame's matrices, and a route's coordinates run

--- a/main.lua
+++ b/main.lua
@@ -82,6 +82,7 @@ end
 
 local Voxel = V.require("VoxelState")
 local Voxel3D = V.require("Voxel3D")
+local ShadowMap = V.require("ShadowMap")
 local VoxelScene = V.require("VoxelScene")
 local ChunkMesher = V.require("ChunkMesher")
 local VoxelGrid = V.require("VoxelGrid")
@@ -111,7 +112,33 @@ local HordeSfx = V.require("HordeSfx")
 local VoxelLoading = V.require("VoxelLoading")
 local DebugOverlay = V.require("DebugOverlay")
 DebugOverlay.install()
+DebugOverlay.setProbe(function()
+  local done, total, running, eta = CachePrebuild.progress()
+  return {
+    voxel = Voxel3D.diagnostics(),
+    shadows = ShadowMap.diagnostics(),
+    cache = {
+      identity = MeshCache.identity(),
+      build = MeshCache.buildInfoSnapshot(),
+      lastFailure = MeshCache.getLastFailure(),
+      saveFailures = MeshCache.saveFailureCount(),
+    },
+    prebuild = {
+      status = CachePrebuild.status(), done = done, total = total,
+      running = running, eta = eta,
+    },
+  }
+end)
+-- The hold chords: five seconds of SELECT toggles debug visibility,
+-- and five seconds of START while the background debugger is running exports its log --
+-- the touch/pad versions of F9 and F8 (see lib/HoldChord.lua). Polled
+-- on the always-running update tick below, because the engine's Input is
+-- the one place every road into a button -- touch overlay, pad, keyboard
+-- aliases -- converges.
+local HoldChord = V.require("HoldChord")
 local publishedLoading
+-- Last DEBUGGER-option value applied to the overlay; see the tick below.
+local lastDebuggerSetting = false
 
 local function publishLoading()
   local loading = Voxel.loading == true
@@ -188,6 +215,14 @@ end
 -- The last drawWorld's render duration, fed into the debug overlay's
 -- frame aggregation by the update tick (drawn before the next update).
 local renderMs = 0
+-- drawWorld diagnostics (finding #6): every early-return path leaves
+-- renderMs frozen at its last real value, so a blank-world report cannot
+-- tell which path fired. These one-shot stamps put the path in the stored
+-- log: the loading canvas (and whether it STAYS stuck), the first real
+-- scene render, and the periods where voxel is inactive (drawWorld never
+-- runs at all).
+local worldDiag = { loadingEntered = 0, loadingReported = false,
+                    inactiveNoted = false, firstRender = false }
 
 function voidFill.check()
   local TileRenderer = require("src.render.TileRenderer")
@@ -224,7 +259,9 @@ mod.content.render_pipelines:register("voxel", {
   -- answer false here, and the engine keeps the vanilla 2D path -- which
   -- is why no caller ever has to guard for a missing 3D pass.
   available = function()
-    return Voxel3D.available()
+    local caps = Voxel3D.diagnostics()
+    DebugOverlay.pipelineAvailable(caps.available, caps.reason, caps)
+    return caps.available
   end,
 
   -- the engine hands over the live level; we ease the camera toward it.
@@ -240,6 +277,7 @@ mod.content.render_pipelines:register("voxel", {
   update = function(dt, level)
     return DebugOverlay.try("voxel-update", function()
     DebugOverlay.frame(dt, renderMs)
+    DebugOverlay.pipelineUpdate(level)
     -- FULL is a preset, so it is applied ON THE PRESS rather than held every
     -- frame: it SETS the other rows and then leaves them alone. Holding them
     -- would make the zoom keys and the wheel dead while the mode was on, and
@@ -306,10 +344,57 @@ mod.content.render_pipelines:register("voxel", {
     -- The cache prebuilder is deliberately independent of the active display
     -- mode: an Options-menu press must keep progressing while VOXEL is OFF.
     DebugOverlay.try("prebuild-tick", CachePrebuild.update)
+    -- The DEBUGGER row (and the mod manager's page) write the stored
+    -- option; F9 and the SELECT chord flip visibility directly, so the
+    -- stored value is only re-applied here when it CHANGES -- never
+    -- fighting a manual toggle, and never hiding a panel the player just
+    -- called up. On Android this option is the only toggle (see the
+    -- SELECT chord gate below).
+    local debuggerOn = false
+    local optMod = V.mod
+    if optMod and optMod.options then
+      local okG, got = pcall(optMod.options.get, optMod.options, "debugger")
+      debuggerOn = okG and got == true
+    end
+    if debuggerOn ~= lastDebuggerSetting then
+      lastDebuggerSetting = debuggerOn
+      DebugOverlay.setVisible(debuggerOn)
+    end
+    -- The hold chords ride the same always-running tick: five seconds
+    -- held fires a chord wherever the cursor is, exactly like the F9 and
+    -- F8 keys. Same guard as F9's too: a screen with its own key handler
+    -- (a text field) never arms a chord. The engine's Input answers for
+    -- every road into a button at once -- the touch overlay's buttons, a
+    -- pad's back/start, and the keyboard aliases. SELECT toggles the
+    -- debugger visibility; START exports its background log -- exporting is
+    -- the retrieval half of the pair.
+    local Input = require("src.core.Input")
+    local holdGame = require("src.core.Game")
+    local holdTop = holdGame.stack and holdGame.stack:top()
+    local chordable = not (holdTop and holdTop.onKeyPressed)
+    -- On mobile the touch overlay's SELECT is a real game button (it feeds
+    -- the same Input state as a pad), so a five-second hold while playing
+    -- must not summon the debug overlay.  The START chord -- the support-log
+    -- export half of the pair -- still works there.
+    local Platform = require("src.core.Platform")
+    local selectChordable = chordable
+      and not (Platform.detect and Platform.detect().mobile)
+    if HoldChord.update("select", dt, selectChordable and Input:isDown("select")) then
+      DebugOverlay.toggle()
+    end
+    if HoldChord.update("start", dt, chordable and DebugOverlay.running()
+                                               and Input:isDown("start")) then
+      DebugOverlay.export()
+    end
     if not Voxel.active() then
+      if not worldDiag.inactiveNoted then
+        worldDiag.inactiveNoted = true
+        DebugOverlay.note("voxel inactive: drawWorld not running")
+      end
       publishLoading()
       return
     end
+    worldDiag.inactiveNoted = false
     local Game = require("src.core.Game")
     local ow = Game and Game.overworld
     if ow and ow.map and ow.camera then
@@ -327,12 +412,18 @@ mod.content.render_pipelines:register("voxel", {
   end,
 
   drawWorld = function(ctx)
+    local function renderWorld()
+    DebugOverlay.pipelinePath("entered")
     if not ctx.state then
+      DebugOverlay.pipelinePath("no_state")
       DebugOverlay.error("drawWorld: no world state to draw")
       return nil
     end
     if not Voxel3D.available() then
-      DebugOverlay.error("drawWorld: 3D unavailable (canvas/shader gate)")
+      local caps = Voxel3D.diagnostics()
+      DebugOverlay.pipelinePath("unavailable", caps)
+      DebugOverlay.error("drawWorld: 3D unavailable (%s): %s",
+                         tostring(caps.reason), tostring(caps.error or ""))
       return nil
     end
     -- the palette closure, stashed for the VR frame: it renders from the
@@ -346,7 +437,10 @@ mod.content.render_pipelines:register("voxel", {
     if VR.active() then
       local sw, sh = sceneSize(ctx)
       local m = VR.mirror(sw, sh)
-      if m then return m end
+      if m then
+        DebugOverlay.pipelinePath("rendered", { path = "vr_mirror" })
+        return m
+      end
     end
     -- Terrain and characters are geometry; the field FX stay ordinary 2D
     -- draws composited on top, anchored through the same camera the 3D
@@ -356,8 +450,31 @@ mod.content.render_pipelines:register("voxel", {
     -- world-pixel units.
     local sw, sh = sceneSize(ctx)
     if Voxel.loading then
+      -- This path returns WITHOUT setting renderMs -- a blank-world report
+      -- with renderMs frozen is drawWorld stuck here. Stamp the entry and,
+      -- if the loading canvas outlives 10s, escalate to a durable error
+      -- naming the pending count.
+      local now = love and love.timer and love.timer.getTime
+                 and love.timer.getTime() or 0
+      if worldDiag.loadingEntered == 0 then
+        worldDiag.loadingEntered = now
+        worldDiag.loadingReported = false
+        DebugOverlay.note("drawWorld: loading canvas (%d pending)",
+                          ChunkMesher.pending())
+      elseif not worldDiag.loadingReported and now > 0
+             and now - worldDiag.loadingEntered > 10 then
+        worldDiag.loadingReported = true
+        DebugOverlay.error("drawWorld: stuck loading %.0fs (%d pending)",
+                           now - worldDiag.loadingEntered,
+                           ChunkMesher.pending())
+      end
+      DebugOverlay.pipelinePath("loading", {
+        pending = ChunkMesher.pending(),
+      })
       return VoxelLoading.draw(sw, sh, ChunkMesher.pending())
     end
+    worldDiag.loadingEntered = 0
+    worldDiag.loadingReported = false
     -- With AA on, the whole pass runs into a canvas BIGGER than the window
     -- and is folded back down at the end (see AntiAlias).  Nothing between
     -- these two lines knows: every pass in the frame measures itself in the
@@ -383,7 +500,14 @@ mod.content.render_pipelines:register("voxel", {
       renderMs = (love.timer.getTime() - t0) * 1000
     end
     if not canvas then
-      DebugOverlay.error("drawWorld: scene returned no canvas (2D fallback)")
+      local reason = Voxel3D.beginFailure or "scene returned no canvas"
+      DebugOverlay.pipelinePath("fallback", { reason = reason })
+      DebugOverlay.error("drawWorld: scene returned no canvas (2D fallback): %s",
+                         reason)
+    end
+    if not worldDiag.firstRender and canvas then
+      worldDiag.firstRender = true
+      DebugOverlay.note("drawWorld: first scene render (%.0fms)", renderMs)
     end
     if not canvas then return nil end   -- fall back to the 2D path
     if Voxel3D.beginOverlay() then
@@ -413,7 +537,14 @@ mod.content.render_pipelines:register("voxel", {
       -- HIGH (or the desktop path): the AA fold only.
       canvas = AntiAlias.resolve(canvas, sw, sh, "world")
     end
+    DebugOverlay.pipelinePath("rendered", {
+      width = crw, height = crh, renderMs = renderMs,
+    })
     return canvas
+    end
+    local ok, result = DebugOverlay.try("voxel-drawWorld", renderWorld)
+    if not ok then error(result, 0) end
+    return result
   end,
 
   invalidate = function()
@@ -650,6 +781,15 @@ local SETTINGS = {
       "fixed rung costs",
       "fill rate and RAM." },
     full = true },
+  -- Debug/support rows: the DEBUGGER panel toggle (Android has no F9 key,
+  -- and its SELECT hold chord is gated off mobile, so this row is the
+  -- touch access) -- SEND LOGS lives with the other actions in
+  -- voxelSettingsRows, as the F8 chord's menu equivalent.
+  { DebugOverlay.setting,
+    { "Show the debug",
+      "panel. OFF hides",
+      "it; the background",
+      "log still records." } },
 }
 
 -- The mod manager's page lists this mod's settings from the same schema:
@@ -1052,6 +1192,17 @@ local function voxelSettingsRows(game)
     value = function() return "DELETE" end,
     activate = confirmCacheWipe,
   }
+  -- F8's touch access: ship the background log right now.  The START hold
+  -- chord does the same on pads/mobile; this row works everywhere the
+  -- VOXEL SETTINGS screen does.
+  rows[#rows + 1] = {
+    id = "potato_voxel:send_logs",
+    label = "SEND LOGS",
+    value = function() return "SEND" end,
+    activate = function()
+      DebugOverlay.export()
+    end,
+  }
   return rows
 end
 
@@ -1222,11 +1373,23 @@ end
 -- new colours land on the diorama already on screen, in one frame, which is
 -- what a palette toggle should look like from inside voxel mode.
 mod.events:on("map.reloaded", function(payload)
+  DebugOverlay.event("map.reloaded", {
+    mapId = payload and payload.mapId,
+    reason = payload and payload.reason,
+  })
   DebugOverlay.trace("event map.reloaded %s (%s)",
                     tostring(payload and payload.mapId), tostring(payload and payload.reason))
   if payload and payload.reason == "colors" then return end
   local mapId = payload and (payload.mapId or (payload.map and payload.map.id))
   if mapId then ChunkMesher.invalidate(mapId) end
+end)
+
+mod.events:on("map.entered", function(payload)
+  DebugOverlay.event("map.entered", {
+    mapId = payload and (payload.mapId or payload.id),
+  })
+  DebugOverlay.trace("event map.entered %s",
+                    tostring(payload and (payload.mapId or payload.id)))
 end)
 
 -- ------- rows come and go, so the menu has to notice
@@ -1425,15 +1588,23 @@ DayTint.install()
 -- save with no clock in it starts at day; that is DayNight.restore's
 -- fallback, and also the DAYTIME row's own default.
 mod.events:on("game.ready", function(payload)
-  if payload and payload.game then CachePrebuild.bootstrap(payload.game) end
+  if payload and payload.game then
+    DebugOverlay.bindGame(payload.game)
+    DebugOverlay.event("game.ready")
+    CachePrebuild.bootstrap(payload.game)
+  end
 end)
 
-mod.events:on("save.writing", function()
+mod.events:on("save.writing", function(payload)
+  DebugOverlay.event("save.writing")
+  if payload and payload.game then DebugOverlay.bindGame(payload.game) end
   DebugOverlay.trace("event save.writing")
   DayNight.store()
 end)
 
-mod.events:on("save.loaded", function()
+mod.events:on("save.loaded", function(payload)
+  DebugOverlay.event("save.loaded")
+  if payload and payload.game then DebugOverlay.bindGame(payload.game) end
   DebugOverlay.trace("event save.loaded")
   DayNight.restore()
   -- a save written before this mod was installed can carry TILT or GBC FX
@@ -1443,7 +1614,9 @@ mod.events:on("save.loaded", function()
   pinEngineFx()
 end)
 
-mod.events:on("save.created", function()
+mod.events:on("save.created", function(payload)
+  DebugOverlay.event("save.created")
+  if payload and payload.game then DebugOverlay.bindGame(payload.game) end
   DebugOverlay.trace("event save.created")
   DayNight.restore()
   pinEngineFx()
@@ -1467,3 +1640,6 @@ mod.exports.lib = V
 -- the Brick tuner, exposed so tests and tooling can probe isBrick() and
 -- the pinned ladders without a device
 mod.exports.brick = BrickProfile
+-- Public support seam: data-only status and export/probe controls without
+-- exposing the live renderer objects themselves.
+mod.exports.debug = DebugOverlay

--- a/main.lua
+++ b/main.lua
@@ -384,7 +384,7 @@ mod.content.render_pipelines:register("voxel", {
     end
     if HoldChord.update("start", dt, chordable and DebugOverlay.running()
                                                and Input:isDown("start")) then
-      DebugOverlay.export()
+      DebugOverlay.export(holdGame)
     end
     if not Voxel.active() then
       if not worldDiag.inactiveNoted then
@@ -934,7 +934,7 @@ do
       return
     end
     if key == "f8" and not (top and top.onKeyPressed) then
-      DebugOverlay.export()
+      DebugOverlay.export(self)
       return
     end
     -- A screen with its own key handler gets the key first, exactly as the
@@ -1199,8 +1199,8 @@ local function voxelSettingsRows(game)
     id = "potato_voxel:send_logs",
     label = "SEND LOGS",
     value = function() return "SEND" end,
-    activate = function()
-      DebugOverlay.export()
+    activate = function(g)
+      DebugOverlay.export(g)
     end,
   }
   return rows

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -273,6 +273,34 @@ if MeshCache.available() then
   T.eq(MeshCache.codec(), "zstd",
        "cache status identifies the zstd codec")
 
+  -- A runtime WITHOUT zstd but WITH zlib (the TrimUI brick's LÖVE ships
+  -- lz4 + zlib only): packPayload falls through to zlib before lz4, and
+  -- the codec-aware decoder + status report it as codec byte 3 / "zlib".
+  testLove.data.compress = function(_, format, body)
+    if format ~= "zlib" then return nil end
+    serial = serial + 1
+    local key = "zlib" .. serial
+    packed[key] = body
+    return key
+  end
+  MeshCache.saveTerrain(fakeMap, "body", vertices, 128)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  local zlibbed = fakeStore.peekBytes()["maps/A/body/terrain"]
+  local zlibCodec = zlibbed
+    and zlibbed:byte(9 + (zlibbed:byte(5) + zlibbed:byte(6) * 256
+                         + zlibbed:byte(7) * 65536 + zlibbed:byte(8) * 16777216))
+    or nil
+  T.eq(zlibCodec, 3,
+       "cache writes codec byte 3 when only zlib is available")
+  local zl = MeshCache.loadTerrain(fakeMap, "body")
+  T.check(zl ~= nil and zl.n == 128,
+          "zlib-compressed payload loads through the codec-aware decoder")
+  T.check(MeshCache.ready({ { id = "A", slot = "body" } }),
+          "zlib cache reports READY from summaries")
+  T.eq(MeshCache.codec(), "zlib",
+       "cache status identifies the zlib codec")
+
   testLove.data = oldData
   _G.love = oldLove
   MeshCache.wipe({ { id = "A", slot = "body" } })

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -22,6 +22,7 @@ T.check(brick ~= nil and brick.isBrick(), "the one build is the Brick build")
 if brick then
   local Voxel = exports.lib.require("VoxelState")
   local ShadowMap = exports.lib.require("ShadowMap")
+  local Voxel3D = exports.lib.require("Voxel3D")
   local Water = exports.lib.require("Water")
   local AntiAlias = exports.lib.require("AntiAlias")
   local WorldCurve = exports.lib.require("WorldCurve")
@@ -104,6 +105,44 @@ if brick then
           "a sane frustum is not degenerate")
   T.check(ShadowMap._source():find("c.z == c.z", 1, true),
           "shadow shader stores far depth instead of NaN")
+  T.check(ShadowMap._source():find(
+            "varying LOVE_HIGHP_OR_MEDIUMP float vDepth", 1, true),
+          "shadow-map depth varying keeps mobile precision")
+  T.check(Voxel3D._source():find(
+            "varying LOVE_HIGHP_OR_MEDIUMP vec3 vSun", 1, true),
+          "scene shadow coordinates keep mobile precision")
+  T.check(Voxel3D._source():find(
+            "precision highp float", 1, true),
+          "scene shadow comparisons request fragment high precision")
+  local scenePinned = Voxel3D._source(false, false)
+  local sceneBare = Voxel3D._source(false, true)
+  T.check(scenePinned:find("#define EFFECT_PREC mediump\n", 1, true),
+          "scene shader pins effect parameters for mobile prototypes")
+  T.check(scenePinned:find(
+            "vec4 effect(EFFECT_PREC vec4 color", 1, true),
+          "scene shader routes effect parameters through the precision define")
+  T.check(sceneBare:find("#define EFFECT_PREC\n", 1, true),
+          "scene shader has a bare-precision retry variant")
+  local shadowPinned = ShadowMap._source(false)
+  local shadowBare = ShadowMap._source(true)
+  T.check(shadowPinned:find("#define EFFECT_PREC mediump\n", 1, true),
+          "shadow shader pins effect parameters for mobile prototypes")
+  T.check(shadowPinned:find(
+            "vec4 effect(EFFECT_PREC vec4 color", 1, true),
+          "shadow shader routes effect parameters through the precision define")
+  T.check(shadowBare:find("#define EFFECT_PREC\n", 1, true),
+          "shadow shader has a bare-precision retry variant")
+  do
+    local caps = Voxel3D.diagnostics()
+    T.check(type(caps) == "table" and type(caps.available) == "boolean",
+            "scene capability diagnostics return a boolean gate")
+    T.check(caps.reason ~= nil,
+            "scene capability diagnostics name the current gate")
+    T.check(type(caps.shaderErrors) == "table",
+            "scene capability diagnostics preserve shader errors")
+  end
+  T.check(type(ShadowMap.diagnostics) == "function",
+          "shadow diagnostics expose capability detail")
   T.check(ShadowMap.abort ~= nil, "abort() exists for pcall error handlers")
   -- Mali (Mediatek) devices: every active rung takes the proven HIGH actor
   -- shadow path -- the blob decal fallback is what freezes/black-frames them
@@ -272,6 +311,102 @@ if brick then
    local Prebuild = exports.lib.require("CachePrebuild")
   local jobs = Prebuild.enumerate({ B = { id="B", width=3, height=2, connections={} }, A = { id="A", width=4, height=5, connections={} } })
   T.eq(#jobs, 4, "prebuild enumerates body and full variants")
+  -- The hold chords: five seconds of SELECT toggles the debug overlay,
+  -- and five seconds of START while the debugger is on exports its log --
+  -- the touch/pad versions of F9 and F8. Each chord is a timer fed the
+  -- engine's Input:isDown answer; releasing early aborts the count.
+  local HoldChord = exports.lib.require("HoldChord")
+  T.eq(HoldChord.SECONDS, 5, "the hold chords are five seconds")
+  T.check(not HoldChord.update("select", 1, true),
+          "a fresh SELECT hold does not fire early")
+  T.check(not HoldChord.update("select", 1, true),
+          "two seconds still short")
+  T.check(not HoldChord.update("select", 0.5, false),
+          "a SELECT release aborts the count")
+  T.check(not HoldChord.update("select", 4, true),
+          "a new SELECT hold restarts from zero")
+  T.check(HoldChord.update("select", 1, true),
+          "the fifth SELECT second fires the chord")
+  T.check(not HoldChord.update("select", 1, true),
+          "a continued SELECT hold does not retrigger")
+  T.check(not HoldChord.update("select", 1, false),
+          "a SELECT release after firing keeps it silent")
+  T.check(not HoldChord.update("start", 4, true),
+          "START counts its own chord independently")
+  T.check(HoldChord.update("start", 1, true),
+          "START fires on its own fifth second")
+  T.check(not HoldChord.update("select", 1, true),
+          "START firing does not disturb SELECT's timer")
+  T.check(HoldChord.update("select", 5, true),
+          "one long frame can cross the SELECT threshold")
+  T.check(not HoldChord.update("select", 1, true),
+          "the crossing frame resets the timer")
+  local DebugOverlay = exports.lib.require("DebugOverlay")
+  T.check(type(DebugOverlay.enabled) == "function",
+          "the overlay exposes its visibility for the START chord")
+  T.check(type(DebugOverlay.running) == "function",
+          "the debugger exposes its background-running state")
+  T.check(DebugOverlay.running(), "the debugger runs in the background at boot")
+  T.check(not DebugOverlay.enabled(), "the debugger starts hidden")
+  T.check(type(DebugOverlay.status) == "function",
+          "the debugger exposes a data-only status snapshot")
+  T.check(type(DebugOverlay.pipelineUpdate) == "function",
+          "the debugger exposes pipeline heartbeat accounting")
+  T.check(type(DebugOverlay.pipelineAvailable) == "function",
+          "the debugger exposes pipeline capability reasons")
+  T.check(type(DebugOverlay.pipelinePath) == "function",
+          "the debugger exposes world-render path accounting")
+  T.check(type(DebugOverlay.runProbe) == "function",
+          "the debugger exposes a capability self-test")
+  do
+    DebugOverlay.pipelineUpdate(5)
+    DebugOverlay.pipelineAvailable(false, "scene_shader_compile",
+                                   { error = "test compiler error" })
+    DebugOverlay.pipelinePath("fallback", { reason = "scene_shader_compile" })
+    local status = DebugOverlay.status()
+    T.eq(status.pipeline.level, 5, "debug status records the live voxel level")
+    T.eq(status.pipeline.updateCalls, 1,
+         "debug status counts pipeline update calls")
+    T.eq(status.pipeline.availability, false,
+         "debug status records pipeline availability")
+    T.eq(status.pipeline.reason, "scene_shader_compile",
+         "debug status records the pipeline failure reason")
+    T.eq(status.pipeline.lastPath, "fallback",
+         "debug status records the world fallback path")
+    T.eq(status.pipeline.fallbacks, 1,
+         "debug status counts world fallbacks")
+    T.check(status.pipeline.detail.error == "test compiler error",
+            "debug status preserves capability details")
+    local probe = DebugOverlay.runProbe()
+    T.check(type(probe) == "table", "debug capability probe returns data")
+  end
+  do
+    local oldLove = _G.love
+    local printed = {}
+    _G.love = {
+      graphics = {
+        getFont = function() return nil end,
+        getColor = function() return 1, 1, 1, 1 end,
+        setFont = function() end,
+        setColor = function() end,
+        rectangle = function() end,
+        print = function(line) printed[#printed + 1] = line end,
+      },
+    }
+    DebugOverlay.note("hidden boot marker")
+    DebugOverlay.toggle()
+    DebugOverlay.draw()
+    local found = false
+    for _, line in ipairs(printed) do
+      if tostring(line):find("hidden boot marker", 1, true) then
+        found = true
+        break
+      end
+    end
+    T.check(found, "background diagnostics remain available when F9 shows the panel")
+    DebugOverlay.toggle()
+    _G.love = oldLove
+  end
 end
 
 -- The MeshCache storage format: encode/decode must round-trip
@@ -513,8 +648,14 @@ if MeshCache and MeshCache.encodeMesh then
       graphics = {
         newMesh = function()
           local m = {}
+          m.vertexMapCalls = {}
           function m.setVertices() end
-          function m.setVertexMap() end
+          function m.setVertexMap(_, map, start)
+            m.vertexMapCalls[#m.vertexMapCalls + 1] = {
+              count = type(map) == "table" and #map or 0,
+              start = start,
+            }
+          end
           function m.release() end
           return m
         end,
@@ -529,6 +670,33 @@ if MeshCache and MeshCache.encodeMesh then
             "the loaded pair answers from memory")
     T.check(ChunkMesher.grass(fastMap) ~= nil,
             "the aux grass rode the same fast path")
+    -- Mesh:setVertexMap replaces the complete map; it has no ranged-update
+    -- overload. The cache loader must therefore call it exactly once with
+    -- the complete index list, even when a large map needs sliced vertices.
+    do
+      local manyQuads, manyBuf, manyIdx = {}, {}, {}
+      for i = 1, 2731 do
+        manyQuads[#manyQuads + 1] = {
+          { 0, 0, 0 }, { 1, 0, 0 }, { 1, 1, 0 }, { 0, 1, 0 },
+          u = 0.25, v = 0.25, shade = 0.5,
+        }
+      end
+      local manyK, manyM = MeshCache.flattenQuads(manyQuads, manyBuf, manyIdx)
+      MeshCache.saveAux(fastMap, "full",
+                        { grass = { n = manyK / 6, buf = manyBuf,
+                                    m = manyM, idx = manyIdx },
+                          flowers = nil, figures = {} })
+      ChunkMesher.release(fastMap.id)
+      local reloaded = ChunkMesher.request(fastMap, false, nil, true)
+      T.check(reloaded ~= nil, "large cached mesh reloads")
+      local grass = ChunkMesher.grass(fastMap)
+      local calls = grass and grass.vertexMapCalls or {}
+      T.eq(#calls, 1, "large cached mesh uploads one complete vertex map")
+      T.eq(calls[1] and calls[1].count, manyM,
+           "large cached mesh uploads every vertex-map index")
+      T.eq(calls[1] and calls[1].start, nil,
+           "vertex-map upload does not pass a false range offset")
+    end
     -- a map with nothing in the box still queues the async cover path
     local coldMap = { id = "FASTPATH_MISS",
                       tileset = { image = "tilesets/sample.png", trueColor = false },

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -407,6 +407,81 @@ if brick then
     DebugOverlay.toggle()
     _G.love = oldLove
   end
+  -- The log-send consent gate: F8 / SEND LOGS / the START chord all land
+  -- on Overlay.export, and a first export that would send stops to ask.
+  -- The engine under test has neither postLog nor a manifest log_url, so
+  -- the gate is exercised with fakes installed -- and with them removed
+  -- the export must pass straight through, exactly as a local-only
+  -- engine does.
+  do
+    local mod = exports.lib.mod
+    local oldPostLog, oldManifest = mod.postLog, mod.manifest
+    local oldTextBox = package.loaded["src.render.TextBox"]
+    local sends, stackPushed = 0, nil
+    -- The prompt is engine UI (src.render.TextBox); stub it so the gate
+    -- can be driven headlessly. The stub records the text and options the
+    -- mod asked with, so the test can answer the choice itself.
+    package.loaded["src.render.TextBox"] = {
+      new = function(_, text, onDone, opts)
+        stackPushed = { text = text, opts = opts }
+        return stackPushed
+      end,
+    }
+    local fakeStack = { push = function(_, s) stackPushed = s end }
+    local consentGame = { save = { options = optionsState },
+                          writeOptions = function() stackPushed = "wrote" end,
+                          stack = fakeStack }
+    local function answeredYes()
+      local box = stackPushed
+      stackPushed = nil
+      T.check(type(box) == "table" and type(box.opts) == "table",
+              "the consent prompt carries a choice")
+      T.check(box.opts.defaultNo == true, "the consent prompt defaults to NO")
+      box.opts.choice(true)
+    end
+    -- Without a send capability the export must never ask: the local
+    -- dump is the whole action there.
+    T.check(not DebugOverlay.canSend(),
+            "no postLog or log_url means nothing can be sent")
+    DebugOverlay.export(consentGame)
+    T.check(stackPushed == nil, "a local-only export does not prompt")
+    mod.postLog = function() sends = sends + 1 return true end
+    mod.manifest = { log_url = "https://logs.example.invalid/logs" }
+    T.check(DebugOverlay.canSend(),
+            "postLog plus a log_url makes a send possible")
+    T.check(not DebugOverlay.consent(),
+            "log-send consent is off before the first export")
+    DebugOverlay.export(consentGame)
+    T.check(stackPushed ~= nil, "the first sendable export asks first")
+    T.eq(sends, 0, "nothing is sent before the prompt is answered")
+    -- YES persists the consent (the same options store every setting
+    -- lives in) and re-runs the export, which now sends.
+    answeredYes()
+    T.check(DebugOverlay.consent(), "a YES is recorded as consent")
+    T.check(optionsState.modOptions.potato_voxel.log_consent == true,
+            "consent is stored in the mod's options")
+    T.eq(sends, 1, "a consented export sends the log")
+    stackPushed = nil
+    DebugOverlay.export(consentGame)
+    T.check(stackPushed == nil, "a consented export never asks again")
+    T.eq(sends, 2, "a consented export sends directly")
+    -- NO sends nothing and leaves the flag unset, so the next export
+    -- asks again.
+    optionsState.modOptions.potato_voxel.log_consent = nil
+    T.check(not DebugOverlay.consent(), "a declined consent stays unset")
+    DebugOverlay.export(consentGame)
+    T.check(stackPushed ~= nil, "an unconsented export asks again")
+    stackPushed.opts.choice(false)
+    T.eq(sends, 2, "a declined prompt sends nothing")
+    T.check(not DebugOverlay.consent(), "declining leaves the flag unset")
+    -- No UI to ask on: refuse rather than ship logs silently.
+    stackPushed = nil
+    DebugOverlay.export({})
+    T.check(stackPushed == nil and sends == 2,
+            "an export with no prompt available sends nothing")
+    mod.postLog, mod.manifest = oldPostLog, oldManifest
+    package.loaded["src.render.TextBox"] = oldTextBox
+  end
 end
 
 -- The MeshCache storage format: encode/decode must round-trip

--- a/tests/sandbox_api_test.lua
+++ b/tests/sandbox_api_test.lua
@@ -9,7 +9,7 @@ local function exists(path)
   return true
 end
 
-local root = exists("main.lua") and "." or "mods/potato_voxel"
+local root = exists("manifest.json") and "." or "mods/potato_voxel"
 local files = { root .. "/main.lua" }
 local listing = assert(io.popen(("find %q/lib %q/data -type f -name '*.lua' | sort")
                               :format(root, root)))

--- a/tests/shadow_runtime_test.lua
+++ b/tests/shadow_runtime_test.lua
@@ -1,0 +1,123 @@
+-- Headless runtime contract for the mobile shadow target.
+--
+-- The host deliberately rejects the implicit { color, depth = true } target
+-- while accepting an explicit depthstencil canvas. This mirrors the class of
+-- GLES backend where colour canvas allocation succeeds but the transient
+-- depth attachment does not. The second assertion protects the independent
+-- world/sprite layer lifetime: a sprite pass failure must not erase a world
+-- map that already finished successfully.
+
+local script = debug.getinfo(1, "S").source:gsub("^@", "")
+local root = script:match("^(.*)[/\\]tests[/\\][^/\\]+$") or "."
+
+local function canvas(w, h, kind)
+  local c = { w = w, h = h, kind = kind }
+  function c.setFilter() end
+  function c.setWrap() end
+  function c.release() end
+  return c
+end
+
+local bound = nil
+local binds = {}
+local rejectExplicit = false
+local rejectImplicit = true
+local oldLove = _G.love
+_G.love = { graphics = {} }
+local g = _G.love.graphics
+
+function g.newCanvas(w, h, opts)
+  if opts and opts.format then
+    if rejectExplicit then
+      error("explicit depth format rejected by test backend")
+    end
+    return canvas(w, h, opts.format)
+  end
+  return canvas(w, h, "color")
+end
+function g.newShader()
+  return { send = function() end }
+end
+function g.setCanvas(target)
+  if rejectImplicit and type(target) == "table" and target.depth == true then
+    error("implicit depth attachment rejected by mobile backend")
+  end
+  bound = target
+  binds[#binds + 1] = target
+end
+function g.getBlendMode() return "alpha", "alphamultiply" end
+function g.clear() end
+function g.setDepthMode() end
+function g.setMeshCullMode() end
+function g.setBlendMode() end
+function g.setShader() end
+function g.setColor() end
+
+local Mat4 = assert(loadfile(root .. "/lib/Mat4.lua"))()
+local Voxel = { level = 1, angle = 0.9, FOCAL = 1.0 }
+local ShadowSettings = { quality = function() return nil end }
+local V = {
+  require = function(name)
+    if name == "Mat4" then return Mat4 end
+    if name == "VoxelState" then return Voxel end
+    if name == "ShadowSettings" then return ShadowSettings end
+    if name == "PixelCanvas" then
+      return assert(loadfile(root .. "/lib/PixelCanvas.lua"))(V)
+    end
+    error("shadow runtime probe: unexpected require " .. tostring(name))
+  end,
+}
+local ShadowMap = assert(loadfile(root .. "/lib/ShadowMap.lua"))(V)
+ShadowMap.BRICK_HIGH_RES = 1024
+
+local passed, failed = 0, 0
+local function check(condition, name)
+  if condition then
+    passed = passed + 1
+  else
+    failed = failed + 1
+    io.write("FAIL: " .. name .. "\n")
+  end
+end
+
+check(ShadowMap.available(), "shadow capability accepts explicit depth target")
+check(ShadowMap.begin(0, 0, 160, 144, false),
+      "world pass begins when implicit depth binding is unavailable")
+local worldDiagnostics = ShadowMap.diagnostics()
+check(worldDiagnostics.depth and worldDiagnostics.depth.binding == "explicit",
+      "diagnostics identify explicit depth binding")
+ShadowMap.finish("world", false)
+check(ShadowMap.diagnostics().worldReady,
+      "world pass becomes ready after finish")
+
+check(ShadowMap.begin(0, 0, 160, 144, true),
+      "sprite pass begins with the shared explicit depth target")
+ShadowMap.abort(true)
+local afterSpriteAbort = ShadowMap.diagnostics()
+check(afterSpriteAbort.worldReady,
+      "sprite abort preserves a completed world layer")
+check(not afterSpriteAbort.spriteReady,
+      "sprite abort leaves only the sprite layer unavailable")
+check(afterSpriteAbort.lastPass == "sprite",
+      "diagnostics identify the aborted sprite pass")
+check(#binds > 0,
+      "shadow pass bound a render target")
+
+-- A second backend rejects explicit depth formats but accepts LOVE's internal
+-- attachment. The fallback must keep the pass alive rather than disabling
+-- shadows just because the preferred format is unavailable.
+ShadowMap.invalidate()
+rejectExplicit = true
+rejectImplicit = false
+check(ShadowMap.available(), "shadow capability accepts internal depth fallback")
+check(ShadowMap.begin(0, 0, 160, 144, false),
+      "world pass falls back to the internal depth target")
+check(ShadowMap.diagnostics().depth.binding == "internal",
+      "diagnostics identify internal depth fallback")
+ShadowMap.finish("world-fallback", false)
+check(ShadowMap.diagnostics().worldReady,
+      "internal depth fallback produces a ready world layer")
+
+_G.love = oldLove
+io.write(("shadow runtime: %d passed, %d failed\n"):format(passed, failed))
+os.exit(failed == 0 and 0 or 1)


### PR DESCRIPTION
## Release 1.6.5 — opt-in consent prompt for F8 log uploads

F8 / SEND LOGS now ask before the first upload: a one-time prompt
explains that the log goes to the mod's developer over the internet,
defaults to NO, and a YES is stored in the mod's options so it is
never asked again. A NO ships nothing and asks again next time;
engines with no log_url never prompt.

Includes the 1.6.4 fixes (mesh index upload, warm cache boots, F8
diagnostics hardening) so `main` carries the released v1.6.4 tree
exactly (commit tree-identical to the v1.6.4 tag).

### Changes
- **lib/DebugOverlay.lua** — `log_consent` option, `canSend`/`consent`/
  `askConsent`, and `Overlay.export(g)` now gates the first send behind
  the one-time prompt (covers F8, the START hold chord, and the
  SEND LOGS row).
- **main.lua** — the three export call sites pass the game so the
  prompt pushes onto the right screen stack.
- **tests/potato_voxel_test.lua** — 18 new headless checks for the gate.
- **manifest.json** — 1.6.5.

All CI gates pass: 193/193 full suite, 78/78 cache suite, sandbox
scan clean, modkit lint + validate ok.