### PR TITLE
Release 1.6.6: identify the platform in sent logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.6.6] - 2026-08-16
+
+### Diagnostics
+
+- Sent logs and status records now identify the platform they came from
+  (Windows, OS X, Linux, Android, iOS, consoles), answered through the
+  engine's Platform module, with the device class appended where it is
+  not obvious (Android (mobile), NX (console)).
+
 ## [1.6.5] - 2026-08-16
 
 ### Diagnostics / privacy

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ The debugger records diagnostics in the background from boot. F9 shows or
 hides its panel, F10 switches its detail level, and F8 exports its log plus a
 capability probe. The export preserves early boot evidence, recent runtime
 lines, and a data-only `debug/status` record containing pipeline eligibility,
-shader/canvas reasons, renderer information, cache/storage state, and world
-render-path counters. It does not add a visible panel until you press F9.
+shader/canvas reasons, renderer information, cache/storage state, world
+render-path counters, and the platform the log came from (Windows, OS X,
+Linux, Android, iOS, consoles). It does not add a visible panel until you
+press F9.
 
 The first export that would send a log to the mod's log service (F8, the
 START hold chord, or SEND LOGS in VOXEL SETTINGS) asks first: a one-time

--- a/lib/DebugOverlay.lua
+++ b/lib/DebugOverlay.lua
@@ -82,7 +82,24 @@ local health = {
   probe = { ok = nil },
   lastEvent = nil,
   lastError = nil,
+  platform = nil,
 }
+
+-- The device class these logs come from.  The mod sandbox forbids raw OS
+-- queries, so the answer comes from the engine's own Platform module --
+-- the same one main.lua reads for its mobile gates -- which resolves the
+-- OS name inside engine code.  Captured once at boot: a device does not
+-- change platform mid-session.
+local function platformName()
+  local ok, Platform = pcall(require, "src.core.Platform")
+  if not ok or type(Platform) ~= "table" then return "?" end
+  local okP, info = pcall(Platform.detect)
+  if not okP or type(info) ~= "table" then return "?" end
+  local osName = tostring(info.os or "?")
+  if osName == "?" or osName == "" then return "?" end
+  local kind = info.console and "console" or info.mobile and "mobile" or nil
+  return kind and (osName .. " (" .. kind .. ")") or osName
+end
 
 local function clock()
   local timer = love and love.timer
@@ -132,6 +149,7 @@ local function snapshot()
     renderer = dataCopy(health.renderer),
     storage = dataCopy(health.storage),
     probe = dataCopy(health.probe),
+    platform = health.platform or platformName(),
     lastEvent = dataCopy(health.lastEvent),
     lastError = dataCopy(health.lastError),
     lastPhase = health.lastPhase,
@@ -163,11 +181,12 @@ local function headerText()
   local lv = health.renderer and health.renderer.love
   local loveVer = lv and (tostring(lv.codename) .. " " .. tostring(lv.major)
     .. "." .. tostring(lv.minor)) or "?"
-  return ("-- potato_voxel diagnostic send --\nmod: %s %s\nengine: %s\nlove: %s\nsession: %s\nframe: %s")
+  return ("-- potato_voxel diagnostic send --\nmod: %s %s\nengine: %s\nlove: %s\nplatform: %s\nsession: %s\nframe: %s")
     :format(tostring(manifest and manifest.name or "potato_voxel"),
             tostring(manifest and manifest.version or "?"),
             tostring(ctx.engineVersion or "?"),
-            loveVer, tostring(sessionId), tostring(health.frame))
+            loveVer, tostring(health.platform or platformName()),
+            tostring(sessionId), tostring(health.frame))
 end
 
 -- Flat status excerpt.  The ring only covers what has happened since boot,
@@ -179,6 +198,7 @@ local function snapshotText()
   local function kv(label, value)
     out[#out + 1] = label .. ": " .. tostring(value)
   end
+  kv("platform", health.platform or platformName())
   local c = counters
   kv("counters", ("jobs=%d errors=%d jobFails=%d cacheHits=%d slowLoads=%d storageFails=%d")
     :format(c.jobs, c.errors, c.jobFails, c.cacheHits, c.slowLoads, c.storageFails))
@@ -657,7 +677,8 @@ function Overlay.export(g)
     pcall(print, "[pv-log] " .. line)
   end
   local current = snapshot()
-  pcall(print, "[pv-status] session=" .. tostring(current.session)
+  pcall(print, "[pv-status] platform=" .. tostring(current.platform)
+             .. " session=" .. tostring(current.session)
              .. " frame=" .. tostring(current.frame)
              .. " pipeline=" .. tostring(current.pipeline.availability)
              .. " reason=" .. tostring(current.pipeline.reason)
@@ -846,6 +867,7 @@ end
 function Overlay.captureEnvironment()
   local g = love and love.graphics
   local out = {}
+  health.platform = platformName()
   if love and love.getVersion then
     local ok, major, minor, revision, codename = pcall(love.getVersion)
     if ok then

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -417,7 +417,7 @@ if brick then
     local mod = exports.lib.mod
     local oldPostLog, oldManifest = mod.postLog, mod.manifest
     local oldTextBox = package.loaded["src.render.TextBox"]
-    local sends, stackPushed = 0, nil
+    local sends, lastBody, stackPushed = 0, nil, nil
     -- The prompt is engine UI (src.render.TextBox); stub it so the gate
     -- can be driven headlessly. The stub records the text and options the
     -- mod asked with, so the test can answer the choice itself.
@@ -445,7 +445,7 @@ if brick then
             "no postLog or log_url means nothing can be sent")
     DebugOverlay.export(consentGame)
     T.check(stackPushed == nil, "a local-only export does not prompt")
-    mod.postLog = function() sends = sends + 1 return true end
+    mod.postLog = function(_, body) sends = sends + 1 lastBody = body return true end
     mod.manifest = { log_url = "https://logs.example.invalid/logs" }
     T.check(DebugOverlay.canSend(),
             "postLog plus a log_url makes a send possible")
@@ -465,6 +465,28 @@ if brick then
     DebugOverlay.export(consentGame)
     T.check(stackPushed == nil, "a consented export never asks again")
     T.eq(sends, 2, "a consented export sends directly")
+    -- The send identity carries the platform the log came from.  The
+    -- engine's Platform module answers it; a stubbed OS shows through
+    -- into the send header, the status excerpt and the data snapshot.
+    do
+      local Platform = require("src.core.Platform")
+      local oldLove = _G.love
+      Platform._resetForTests()
+      _G.love = { system = { getOS = function() return "Android" end } }
+      DebugOverlay.captureEnvironment()
+      Platform._resetForTests()
+      _G.love = oldLove
+      T.eq(DebugOverlay.status().platform, "Android (mobile)",
+           "the status snapshot names the platform and its class")
+      stackPushed = nil
+      DebugOverlay.export(consentGame)
+      T.eq(sends, 3, "a consented export sends after the platform capture")
+      T.check(lastBody and lastBody:find("platform: Android (mobile)", 1, true),
+              "the send header carries the platform")
+      T.check(lastBody and lastBody:find("-- status excerpt --", 1, true)
+              and lastBody:find("platform: Android (mobile)", 1, true),
+              "the send's status excerpt carries the platform")
+    end
     -- NO sends nothing and leaves the flag unset, so the next export
     -- asks again.
     optionsState.modOptions.potato_voxel.log_consent = nil
@@ -472,12 +494,12 @@ if brick then
     DebugOverlay.export(consentGame)
     T.check(stackPushed ~= nil, "an unconsented export asks again")
     stackPushed.opts.choice(false)
-    T.eq(sends, 2, "a declined prompt sends nothing")
+    T.eq(sends, 3, "a declined prompt sends nothing")
     T.check(not DebugOverlay.consent(), "declining leaves the flag unset")
     -- No UI to ask on: refuse rather than ship logs silently.
     stackPushed = nil
     DebugOverlay.export({})
-    T.check(stackPushed == nil and sends == 2,
+    T.check(stackPushed == nil and sends == 3,
             "an export with no prompt available sends nothing")
     mod.postLog, mod.manifest = oldPostLog, oldManifest
     package.loaded["src.render.TextBox"] = oldTextBox


### PR DESCRIPTION
## 1.6.6 — identify the platform in sent logs

The debugger's logs now say where they came from. Platform is captured
once at boot through the engine's Platform module and appears in the
send header, the status excerpt, the stored `debug/status` record, and
the console export line: `platform: Windows`, `Android (mobile)`,
`NX (console)`, etc.

### Changes
- **lib/DebugOverlay.lua** — `platformName()` helper (engine Platform
  module; the sandbox forbids raw OS queries) + `platform:` in the
  payload header, status excerpt, data snapshot, and `[pv-status]` line.
- **tests/potato_voxel_test.lua** — 4 new checks (status snapshot, send
  header, status excerpt carry the platform).
- **manifest.json** — 1.6.6.

Verified: 197/197 full suite, 78/78 cache suite, sandbox scan clean,
modkit lint + validate ok.