### PR TITLE
Release 1.6.7: GPU/renderer/shadow/settings diagnostics in sent logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.6.7] - 2026-08-16
+
+### Diagnostics
+
+- Sent logs now identify the GPU behind every render and shadow report:
+  the header carries `gpu:` (backend + device), and the status excerpt
+  carries the full renderer identity (name/vendor/device/version), the
+  DPI scale (a fractional scale is where canvas and scissor bugs come
+  from), and the complete shadow-system state -- shader precision,
+  depth-attachment binding, sprite layer, pass aborts -- plus the
+  retained failure text when the shadow or voxel pass is unavailable
+  (which shader would not compile, which canvas could not be allocated,
+  what the driver said). Renderer capture now accepts both LÖVE 12's
+  table `getRendererInfo` and LÖVE 11's four-value form, so desktop
+  sends carry it too.
+
 ## [1.6.6] - 2026-08-16
 
 ### Diagnostics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
   what the driver said). Renderer capture now accepts both LÖVE 12's
   table `getRendererInfo` and LÖVE 11's four-value form, so desktop
   sends carry it too.
+- The status excerpt now carries the session's VOXEL SETTINGS as one
+  `settings:` line -- the voxel rung plus every live setting row as
+  `key=label` (WATER, AA, V-CURVE, V-GRID, 3D-BTL, DAY/NIGHT, SHADOWS,
+  SHADOW QUALITY, RENDER SCALE, DEBUGGER) -- read live through the same
+  paths the menu rows use, so a received log shows exactly what the
+  session ran with. Gated rows are omitted exactly as the menu omits
+  them.
 
 ## [1.6.6] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ The debugger records diagnostics in the background from boot. F9 shows or
 hides its panel, F10 switches its detail level, and F8 exports its log plus a
 capability probe. The export preserves early boot evidence, recent runtime
 lines, and a data-only `debug/status` record containing pipeline eligibility,
-shader/canvas reasons, renderer information, cache/storage state, world
-render-path counters, and the platform the log came from (Windows, OS X,
-Linux, Android, iOS, consoles). It does not add a visible panel until you
-press F9.
+shader/canvas reasons, cache/storage state, world render-path counters, and
+the identity of the device it came from: the platform (Windows, OS X, Linux,
+Android, iOS, consoles), the GPU (backend, vendor, device, version) and the
+DPI scale, plus the full shadow-system state (shader precision, depth
+binding, sprite layer) and the retained failure text when the shadow or
+voxel pass is unavailable. It does not add a visible panel until you press
+F9.
 
 The first export that would send a log to the mod's log service (F8, the
 START hold chord, or SEND LOGS in VOXEL SETTINGS) asks first: a one-time

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ lines, and a data-only `debug/status` record containing pipeline eligibility,
 shader/canvas reasons, cache/storage state, world render-path counters, and
 the identity of the device it came from: the platform (Windows, OS X, Linux,
 Android, iOS, consoles), the GPU (backend, vendor, device, version) and the
-DPI scale, plus the full shadow-system state (shader precision, depth
+DPI scale, the session's VOXEL SETTINGS (rung and every live knob as
+`key=label`), plus the full shadow-system state (shader precision, depth
 binding, sprite layer) and the retained failure text when the shadow or
 voxel pass is unavailable. It does not add a visible panel until you press
 F9.

--- a/lib/DebugOverlay.lua
+++ b/lib/DebugOverlay.lua
@@ -101,6 +101,23 @@ local function platformName()
   return kind and (osName .. " (" .. kind .. ")") or osName
 end
 
+-- The VOXEL SETTINGS summary, provided by main.lua (it owns the rows and
+-- the live options API): one space-separated `key=label` line so a
+-- received log shows exactly the rung and knobs the session ran with.
+-- Read live at send time through the same paths the rows read, so the
+-- excerpt can never disagree with what the menu showed.
+local settingsReader = nil
+function Overlay.setSettingsReader(fn)
+  settingsReader = type(fn) == "function" and fn or nil
+end
+
+local function settingsLine()
+  if not settingsReader then return nil end
+  local ok, got = pcall(settingsReader)
+  if not ok or type(got) ~= "string" or got == "" then return nil end
+  return got
+end
+
 local function clock()
   local timer = love and love.timer
   if timer and timer.getTime then
@@ -150,6 +167,7 @@ local function snapshot()
     storage = dataCopy(health.storage),
     probe = dataCopy(health.probe),
     platform = health.platform or platformName(),
+    settings = settingsLine(),
     lastEvent = dataCopy(health.lastEvent),
     lastError = dataCopy(health.lastError),
     lastPhase = health.lastPhase,
@@ -233,6 +251,8 @@ local function snapshotText()
     kv("screen", ("%dx%d dpi=%s"):format(env.dimensions.w, env.dimensions.h,
       ("%.2f"):format(env.pixelDimensions.w / env.dimensions.w)))
   end
+  local line = settingsLine()
+  if line then kv("settings", line) end
   local v = health.capabilities and health.capabilities.voxel
   if v then
     local depthFailed = v.depth and (#v.depth.failures or 0) > 0

--- a/lib/DebugOverlay.lua
+++ b/lib/DebugOverlay.lua
@@ -181,12 +181,18 @@ local function headerText()
   local lv = health.renderer and health.renderer.love
   local loveVer = lv and (tostring(lv.codename) .. " " .. tostring(lv.major)
     .. "." .. tostring(lv.minor)) or "?"
-  return ("-- potato_voxel diagnostic send --\nmod: %s %s\nengine: %s\nlove: %s\nplatform: %s\nsession: %s\nframe: %s")
+  -- The GPU identity, first thing a received log is sorted by. LÖVE 12's
+  -- getRendererInfo returns one table; LÖVE 11's four values (see
+  -- captureEnvironment, which normalises both).
+  local ri = health.renderer and health.renderer.renderer
+  local gpu = ri and ((tostring(ri.name or "") .. " " .. tostring(ri.device or ""))
+    :gsub("%s+$", "")) or "?"
+  return ("-- potato_voxel diagnostic send --\nmod: %s %s\nengine: %s\nlove: %s\nplatform: %s\ngpu: %s\nsession: %s\nframe: %s")
     :format(tostring(manifest and manifest.name or "potato_voxel"),
             tostring(manifest and manifest.version or "?"),
             tostring(ctx.engineVersion or "?"),
             loveVer, tostring(health.platform or platformName()),
-            tostring(sessionId), tostring(health.frame))
+            gpu, tostring(sessionId), tostring(health.frame))
 end
 
 -- Flat status excerpt.  The ring only covers what has happened since boot,
@@ -212,17 +218,52 @@ local function snapshotText()
         :format(tostring(p.lastPathDetail.renderMs), tostring(p.lastPathFrame)))
     end
   end
+  -- The GPU and screen behind every render and shadow issue: which
+  -- backend (Metal/GL), which vendor/device, and the DPI scale (a
+  -- fractional scale is where canvas and scissor bugs come from).
+  local env = health.renderer
+  local ri = env and env.renderer
+  if ri then
+    kv("renderer", ("%s %s %s %s"):format(tostring(ri.name or "?"),
+      tostring(ri.vendor or ""), tostring(ri.device or ""),
+      tostring(ri.version or "")))
+  end
+  if env and env.dimensions and env.pixelDimensions
+     and env.dimensions.w and env.dimensions.w > 0 then
+    kv("screen", ("%dx%d dpi=%s"):format(env.dimensions.w, env.dimensions.h,
+      ("%.2f"):format(env.pixelDimensions.w / env.dimensions.w)))
+  end
   local v = health.capabilities and health.capabilities.voxel
   if v then
-    kv("voxel", ("available=%s reason=%s")
-      :format(tostring(v.available), tostring(v.reason)))
+    local depthFailed = v.depth and (#v.depth.failures or 0) > 0
+    kv("voxel", ("available=%s reason=%s shader=%s precision=%s depth=%s")
+      :format(tostring(v.available), tostring(v.reason),
+              tostring(v.shader and (v.shader.plain and "ok" or "missing") or "?"),
+              tostring(v.shaderPrecision and v.shaderPrecision.plain or "?"),
+              tostring(depthFailed and "failed" or "ok")))
   end
   local pr = health.probe and health.probe.result
   if pr then
     if pr.shadows then
-      kv("shadows", ("available=%s reason=%s resolution=%s")
-        :format(tostring(pr.shadows.available), tostring(pr.shadows.reason),
-                tostring(pr.shadows.resolution)))
+      local s = pr.shadows
+      kv("shadows", ("available=%s reason=%s res=%s precision=%s depth=%s sprites=%s aborts=%d")
+        :format(tostring(s.available), tostring(s.reason), tostring(s.resolution),
+                tostring(s.shaderPrecision or "?"),
+                tostring(s.depth and s.depth.binding or "?"),
+                tostring(s.spriteReady == true and "on"
+                         or (s.spriteReady == false and "off" or "?")),
+                (s.passCounts and s.passCounts.aborts) or 0))
+      -- An unavailable pass ships the retained failure text -- which shader
+      -- would not compile, which canvas could not be allocated, what the
+      -- driver said -- instead of a bare unavailable=no.
+      if not s.available then
+        local d = s.depth or {}
+        kv("shadowFail", ("shader=%s canvas=%s depth=%s last=%s")
+          :format(tostring(s.shaderError or s.shaderFallbackError or "?"),
+                  tostring(s.canvasError or "?"),
+                  tostring(d.error or d.fallbackError or "?"),
+                  tostring(s.lastFailure or "?")))
+      end
     end
     if pr.cache then
       kv("cache", ("identity=%s saveFailures=%d")
@@ -677,7 +718,9 @@ function Overlay.export(g)
     pcall(print, "[pv-log] " .. line)
   end
   local current = snapshot()
+  local curGpu = current.renderer and current.renderer.renderer
   pcall(print, "[pv-status] platform=" .. tostring(current.platform)
+             .. " gpu=" .. tostring(curGpu and curGpu.name or "?")
              .. " session=" .. tostring(current.session)
              .. " frame=" .. tostring(current.frame)
              .. " pipeline=" .. tostring(current.pipeline.availability)
@@ -877,8 +920,16 @@ function Overlay.captureEnvironment()
   end
   if g then
     if g.getRendererInfo then
-      local ok, info = pcall(g.getRendererInfo)
-      if ok and type(info) == "table" then out.renderer = dataCopy(info) end
+      -- LÖVE 12 returns one table (name/vendor/device/version); LÖVE 11
+      -- returns four values. Both are the same identity -- the GPU and
+      -- the backend behind every render and shadow issue.
+      local ok, a, b, c, d = pcall(g.getRendererInfo)
+      if ok and type(a) == "table" then
+        out.renderer = dataCopy(a)
+      elseif ok and a then
+        out.renderer = { name = tostring(a), vendor = tostring(b or ""),
+                         device = tostring(c or ""), version = tostring(d or "") }
+      end
     end
     if g.getDimensions then
       local ok, w, h = pcall(g.getDimensions)

--- a/main.lua
+++ b/main.lua
@@ -811,6 +811,25 @@ for _, entry in ipairs(SETTINGS) do
 end
 mod.options:define(schema)
 
+-- The VOXEL SETTINGS summary the debugger ships: the voxel rung plus every
+-- live setting row as `key=label`, so a received log shows exactly what the
+-- session ran with. Read live at send time through the same paths the rows
+-- use, and gated rows are omitted exactly as the menu omits them.
+DebugOverlay.setSettingsReader(function()
+  local Pipelines = require("src.render.Pipelines")
+  local out = { "voxel=" .. tostring(Pipelines.levelLabel("voxel")) }
+  for _, entry in ipairs(SETTINGS) do
+    if not entry.when or entry.when() then
+      local setting = entry[1]
+      local i = setting:read()
+      if not setting:allows(i) then i = 1 end
+      out[#out + 1] = tostring(setting.key) .. "="
+                      .. tostring(setting.labels[i] or "?")
+    end
+  end
+  return table.concat(out, " ")
+end)
+
 -- ------- this mod's hotkeys
 --
 --   3  VOXEL    cycle the camera ladder      (was 6; skips FULL)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -495,6 +495,12 @@ if brick then
            "the status snapshot names the GPU backend")
       T.eq(DebugOverlay.status().renderer.renderer.device, "Apple A13 GPU",
            "the status snapshot names the GPU device")
+      local statusSettings = DebugOverlay.status().settings
+      T.check(type(statusSettings) == "string"
+              and statusSettings:find("voxel=", 1, true) ~= nil
+              and statusSettings:find(" water=", 1, true) ~= nil
+              and statusSettings:find(" shadows=", 1, true) ~= nil,
+              "the status snapshot carries the VOXEL SETTINGS line")
       stackPushed = nil
       DebugOverlay.export(consentGame)
       T.eq(sends, 3, "a consented export sends after the platform capture")
@@ -509,6 +515,10 @@ if brick then
               "the status excerpt carries the full renderer identity")
       T.check(lastBody and lastBody:find("screen: 200x100 dpi=3.00", 1, true),
               "the status excerpt carries the DPI scale")
+      T.check(lastBody and lastBody:find("settings: voxel=", 1, true)
+              and lastBody:find(" water=", 1, true)
+              and lastBody:find(" shadows=", 1, true),
+              "the status excerpt carries the VOXEL SETTINGS line")
       T.check(lastBody and lastBody:find("shadows: available=", 1, true)
               and lastBody:find("precision=", 1, true)
               and lastBody:find("depth=", 1, true),

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -465,27 +465,58 @@ if brick then
     DebugOverlay.export(consentGame)
     T.check(stackPushed == nil, "a consented export never asks again")
     T.eq(sends, 2, "a consented export sends directly")
-    -- The send identity carries the platform the log came from.  The
-    -- engine's Platform module answers it; a stubbed OS shows through
-    -- into the send header, the status excerpt and the data snapshot.
+    -- The send identity carries the platform AND the GPU the log came
+    -- from.  The engine's Platform module answers the OS; captureEnvironment
+    -- answers the renderer (LÖVE 12's table shape) and the DPI scale --
+    -- the two facts every render/shadow report is sorted by.  All of it
+    -- shows through into the send header, the status excerpt and the data
+    -- snapshot.
     do
       local Platform = require("src.core.Platform")
       local oldLove = _G.love
       Platform._resetForTests()
-      _G.love = { system = { getOS = function() return "Android" end } }
+      _G.love = {
+        system = { getOS = function() return "Android" end },
+        graphics = {
+          getRendererInfo = function()
+            return { name = "Metal", vendor = "Apple",
+                     device = "Apple A13 GPU", version = "3.2" }
+          end,
+          getDimensions = function() return 200, 100 end,
+          getPixelDimensions = function() return 600, 300 end,
+        },
+      }
       DebugOverlay.captureEnvironment()
       Platform._resetForTests()
       _G.love = oldLove
       T.eq(DebugOverlay.status().platform, "Android (mobile)",
            "the status snapshot names the platform and its class")
+      T.eq(DebugOverlay.status().renderer.renderer.name, "Metal",
+           "the status snapshot names the GPU backend")
+      T.eq(DebugOverlay.status().renderer.renderer.device, "Apple A13 GPU",
+           "the status snapshot names the GPU device")
       stackPushed = nil
       DebugOverlay.export(consentGame)
       T.eq(sends, 3, "a consented export sends after the platform capture")
       T.check(lastBody and lastBody:find("platform: Android (mobile)", 1, true),
               "the send header carries the platform")
+      T.check(lastBody and lastBody:find("gpu: Metal Apple A13 GPU", 1, true),
+              "the send header carries the GPU")
       T.check(lastBody and lastBody:find("-- status excerpt --", 1, true)
               and lastBody:find("platform: Android (mobile)", 1, true),
               "the send's status excerpt carries the platform")
+      T.check(lastBody and lastBody:find("renderer: Metal Apple Apple A13 GPU 3.2", 1, true),
+              "the status excerpt carries the full renderer identity")
+      T.check(lastBody and lastBody:find("screen: 200x100 dpi=3.00", 1, true),
+              "the status excerpt carries the DPI scale")
+      T.check(lastBody and lastBody:find("shadows: available=", 1, true)
+              and lastBody:find("precision=", 1, true)
+              and lastBody:find("depth=", 1, true),
+              "the status excerpt carries the shadow shader and depth state")
+      T.check(lastBody and lastBody:find("voxel: available=", 1, true)
+              and lastBody:find("shader=", 1, true)
+              and lastBody:find("precision=", 1, true),
+              "the status excerpt carries the voxel shader state")
     end
     -- NO sends nothing and leaves the flag unset, so the next export
     -- asks again.


### PR DESCRIPTION
Sent logs now identify the device and configuration behind every render/shadow report: the GPU (backend, vendor, device, version), the DPI scale, the sessions VOXEL SETTINGS (rung + every live knob as key=label), and the complete shadow-system state (shader precision, depth binding, sprite layer) with retained failure text. Manifest 1.6.7. Verified: 206/206 suite, 78/78 cache, sandbox clean, modkit ok.