### PR TITLE
fix: qualify effect()'s return precision so the seam matches LOVE's prototype

### DIFF
--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -182,7 +182,7 @@ local SHADER = [[
 #endif
 #endif
   uniform float sprite;   // 1 while the CAST is being drawn; see ShadowMap.sprites
-  vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
+  EFFECT_PREC vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
               EFFECT_PREC vec2 sc) {
     // the same alpha discard the main pass uses: a sprite card casts its
     // silhouette, not its 16x16 bounding box

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -258,7 +258,7 @@ local SHADER = [[
   uniform float glassGlint;   // and its strength: 0 while standing still
   uniform float glassOn;      // 0 for sprite-sheet draws (see Voxel3D.glass)
 
-  vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
+  EFFECT_PREC vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
               EFFECT_PREC vec2 sc) {
     vec4 p = Texel(tex, tc);
     // sprite sheets key GB OBJ color 0 to alpha 0; discarding rather than

--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -948,7 +948,7 @@ vec2 waveUV(vec2 tc, vec2 col) {
 // the Lua side fills in, and Water.shader compiles the pinned form first
 // and the bare one only if that is refused. Whichever prototype a runtime
 // brought, one of the two agrees with it.
-vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
+EFFECT_PREC vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
             EFFECT_PREC vec2 sc) {
   // THE DEPTH TEST, done here because the buffer that would have done it is
   // detached for the length of this pass so it can be READ (see the header).


### PR DESCRIPTION
### The bug

On Mali-G31 (LÖVE 11.5, GLES) every `effect()` shader in the mod fails to
compile after 1.6.4. With water and shadows enabled, all three go down:

```
[warn]  water shader did not compile: Cannot compile pixel shader code:
        shadows unavailable: the shadow shader did not compile: mediump: ...
        pipeline voxel available=false reason=scene_shader_compile
```

The mod loads normally — `loaded mod potato_voxel 1.6.5` — but the overworld
draws flat, lakes draw flat and shadows are unavailable. `draws=0 path=never`:
the 3D path never runs.

### Why the two-variant seam cannot win

LÖVE's fragment preamble emits `precision mediump float` and then forward
declares the entry point **unqualified**:

```glsl
vec4 effect(vec4 vcolor, Image tex, vec2 texcoord, vec2 pixcoord);
```

So the prototype is a **mediump return and mediump parameters**. The shaders
then raise the stage default to `highp`, and from that point no definition can
match on a driver that enforces this:

| Variant | Parameters | Return type | Result |
|---|---|---|---|
| `EFFECT_PREC mediump` | match | becomes `highp` | **return type mismatch** |
| `EFFECT_PREC` (bare) | become `highp` | match | **parameter mismatch** |

Exactly the two errors the driver reports:

```
mediump: S0023: Function 'effect' redeclared with a different precision
                qualifier on the return type
default: ERROR: 'highp' : overloaded functions must have the same parameter
                precision qualifiers for argument 1 / 3 / 4
```

The bare retry exists to rescue the pinned variant, but the `highp` stage
default guarantees it fails the other way.

### The fix

Qualify the return type with the same `EFFECT_PREC` the parameters already use,
so the pinned variant matches the prototype exactly. Three lines, one per
shader. **The `highp` stage default is kept** — the precision these passes
wanted is unchanged, and the bare fallback still covers runtimes whose
prototype differs.

### Verified on hardware

Anbernic RG35XXSP (Mali-G31, muOS), engine 0.1.96, mod 1.6.5, with
`water = "full"` and `shadows = true` so all three shaders actually compile.
Same map and settings before and after:

| | Water | ShadowMap | Voxel3D |
|---|---|---|---|
| stock 1.6.5 | did not compile | did not compile | did not compile |
| this change | clean | clean | `avail=true reason=ready path=rendered` |

An intermediate build with only `Voxel3D.lua` patched compiled that shader while
water and shadows still failed, which isolates the return-type qualifier as the
operative change rather than anything incidental to the voxel shader.

### Why this should be safe elsewhere

LÖVE's desktop header defines the precision keywords away entirely:

```glsl
#define lowp
#define mediump
#define highp
```

so on desktop `EFFECT_PREC vec4 effect(...)` expands to `vec4 effect(...)` —
textually identical to today. And the GLES header emits its default
unconditionally:

```glsl
#ifdef GL_ES
	precision mediump float;
#endif
```

so on any GLES runtime the prototype's return is mediump, which is what the
pinned variant now matches. That leaves:

| Runtime | Before | After |
|---|---|---|
| desktop GL | qualifiers expand to nothing | identical — no-op |
| GLES with fragment highp | broken (both variants) | fixed |
| GLES without fragment highp | pinned matched (default already mediump) | unchanged |

The bare fallback is untouched, so anything currently compiling through it still
does. Desktop was also checked directly (macOS build, mod loaded, pipeline
`avail=true reason=ready path=rendered`, no compile failures).

### Note on the log output

`ERROR: '' : missing #endif` also appears in the driver output. It is a cascade
artifact — the preprocessor nesting is balanced (verified, 8 matched pairs); the
compiler aborts after the real errors and emits it as noise.

### Possible follow-up

The retained `shaderErrors` are only reachable through the debug overlay, which
needs a keyboard — not available on a handheld. A one-line `print` in the
compile-failure branch is what surfaced the compiler text above; happy to send
that separately if it would help future mobile reports.
