### PR TITLE
Release 1.6.8: Switch cache fixes (platform-gated codec, wipe verification, boot handoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Changelog
 
-## [1.6.7] - 2026-08-16
+## [1.6.8] - 2026-08-16
+
+### Cache (Switch)
+
+- Platform detection: the mod now answers "is this the Switch port?"
+  through a small wrapper (`lib/Platform.lua`) over the engine's own
+  Platform module (the NX flag -- the sandbox forbids the mod touching
+  love.system itself). Every Switch-only cache change below gates on it;
+  desktop and other platforms run exactly as before.
+- Compression codec: on Switch, `packPayload` now prefers lz4 over zlib
+  when zstd is absent. zlib's compress is a multi-hundred-ms main-thread
+  stall per big payload, and the Switch-port logs showed the same
+  prebuild tail running ~2x faster with lz4 than with zlib (zlib vs lz4
+  manifests). The quantized payloads lose little ratio, so the faster
+  codec wins on the console; elsewhere the chain stays zstd -> zlib ->
+  lz4.
+- WIPE CACHE now verifies on Switch: after deleting, the wipe read-backs
+  the manifest/buildinfo and re-lists both payload namespaces, counts
+  every survivor as a storage failure, and reports false instead of
+  claiming success. The Switch storage has been observed to no-op
+  deletes while reporting success -- after a wipe the prebuild restarted
+  from zero (manifest/metas gone) while the old payloads kept serving
+  cache hits.
+- Boot invalidation: on Switch, the engine's Assets.installLoader ->
+  Assets.invalidate handoff has been observed to fire twice at boot; the
+  second call dropped the manifest and forced a cold 444-job prebuild on
+  every launch. Handoff invalidations are now ignored until the first
+  mesh entry exists (which a boot-time handoff can never be), so Switch
+  restarts stay warm; real invalidations still land the moment any mesh
+  work starts.
+- `deleteKey` now returns the storage call's real result instead of
+  swallowing it; no caller's behavior changes off-Switch.## [1.6.7] - 2026-08-16
 
 ### Diagnostics
 

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -51,6 +51,7 @@
 local V = ...
 
 local Assets = require("src.render.Assets")
+local Platform = V.require("Platform")
 local Structures = V.require("Structures")
 local TileShape = V.require("TileShape")
 local Voxel3D = V.require("Voxel3D")
@@ -948,11 +949,17 @@ end
 
 -- ------------------------------------------------------------- the cache
 
+-- True once any map has created a mesh entry. The Assets boot-handoff
+-- guard below uses it to tell "engine still booting" from "real asset
+-- change" on Switch (see the guard for why that platform needs it).
+local builtAnything = false
+
 local function entry(id)
   local c = cache[id]
   if not c then
     c = {}
     cache[id] = c
+    builtAnything = true
   end
   return c
 end
@@ -1663,6 +1670,16 @@ Assets.register(function()
     bootAssetsHandedOff = true
     return
   end
+  -- On Switch the engine's installLoader -> Assets.invalidate handoff
+  -- has been observed to fire TWICE at boot: the guard above skips only
+  -- the first, and the second drops the manifest and forces a cold
+  -- 444-job prebuild on every launch (port log: "cache invalidate ALL"
+  -- 18ms after boot, before save.created). No map can have meshed at
+  -- that point, so skip handoffs until the first real entry exists --
+  -- a boot-time handoff is never that, and Switch cannot hot-reload
+  -- assets during boot anyway. The moment any mesh work starts the
+  -- guard releases, so genuine invalidations still land.
+  if Platform.isSwitch() and not builtAnything then return end
   ChunkMesher.invalidate()
 end)
 

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -36,6 +36,7 @@ local V = ...
 
 local Brick = V.require("BrickProfile")
 local Budget = V.require("BuildBudget")
+local Platform = V.require("Platform")
 
 -- The engine's save-root resolver used to pick the portable SD-card dir.
 -- With storage the engine owns placement entirely; SaveData is no longer
@@ -229,8 +230,13 @@ end
 local function deleteKey(key)
   local store_ = facade()
   if not store_ or not store_.delete then return false end
-  pcall(store_.delete, store_, liveGame(), key)
-  return true
+  -- Return the storage call's real outcome instead of swallowing it: the
+  -- Switch scoped-storage delete has been observed to no-op while this
+  -- function still reported true, which hid the wipe bug (callers that
+  -- relied on the old unconditional true are unchanged -- they just do
+  -- not trust the result yet; MeshCache.wipe verifies by read-back).
+  local ok = pcall(store_.delete, store_, liveGame(), key)
+  return ok
 end
 
 function MeshCache.dir()
@@ -573,6 +579,19 @@ local function packPayload(fp, body)
     if ok and type(packed) == "string" and #packed < #body then
       return header(fp, COMPRESSED_FORMAT, #body, #packed, 0, ZSTD_CODEC)
              .. packed
+    end
+    -- On Switch zstd is absent and zlib's compress is a multi-hundred-ms
+    -- main-thread stall per big payload; the same prebuild tail ran ~2x
+    -- faster with lz4 than with zlib in the Switch-port logs (zlib vs
+    -- lz4 manifests). The payloads are quantized (already entropy-coded),
+    -- so lz4's weaker ratio costs little -- prefer it before zlib there.
+    -- Everywhere else the chain stays zstd -> zlib -> lz4.
+    if Platform.isSwitch() then
+      ok, packed = pcall(data.compress, "string", "lz4", body)
+      if ok and type(packed) == "string" and #packed < #body then
+        return header(fp, COMPRESSED_FORMAT, #body, #packed, 0, LZ4_CODEC)
+               .. packed
+      end
     end
     ok, packed = pcall(data.compress, "string", "zlib", body)
     if ok and type(packed) == "string" and #packed < #body then
@@ -1401,11 +1420,43 @@ function MeshCache.wipe(jobs)
   -- both namespaces. (The prefix pass catches stale payloads from maps
   -- no longer present in the current data, which the jobs pass alone
   -- would leave behind.)
-  for _, key in ipairs(listKeys("maps")) do
+  local mapsKeys = listKeys("maps")
+  local metaKeys = listKeys("meta")
+  for _, key in ipairs(mapsKeys) do
     deleteKey(key)
   end
-  for _, key in ipairs(listKeys("meta")) do
+  for _, key in ipairs(metaKeys) do
     deleteKey(key)
+  end
+  -- On Switch the scoped-storage delete has been observed to no-op while
+  -- reporting success: after a wipe the prebuild restarted from zero
+  -- (manifest/metas gone) yet the old payloads kept serving cache hits.
+  -- Verify by read-back and re-list, count survivors as storage
+  -- failures, and answer false so Prebuild.wipe does not reset its state
+  -- over a wipe that did not land. Other platforms keep the historical
+  -- fire-and-forget behavior.
+  if Platform.isSwitch() then
+    local survivors = {}
+    if readTable(MANIFEST_KEY) ~= nil then
+      survivors[#survivors + 1] = MANIFEST_KEY
+    end
+    if readTable(BUILD_INFO_KEY) ~= nil then
+      survivors[#survivors + 1] = BUILD_INFO_KEY
+    end
+    for _, key in ipairs(listKeys("maps")) do
+      survivors[#survivors + 1] = key
+    end
+    for _, key in ipairs(listKeys("meta")) do
+      survivors[#survivors + 1] = key
+    end
+    if #survivors > 0 then
+      local okD2, Overlay2 = pcall(V.require, "DebugOverlay")
+      if okD2 and Overlay2 then
+        Overlay2.count("storageFails")
+        Overlay2.error("cache wipe: %d key(s) survived delete", #survivors)
+      end
+      return false
+    end
   end
   return true
 end

--- a/lib/Platform.lua
+++ b/lib/Platform.lua
@@ -1,0 +1,46 @@
+-- Platform detection for the voxel build.
+--
+-- The mod sandbox forbids raw OS queries from mod code, so the answer
+-- comes from the engine's own Platform module (src.core.Platform) -- the
+-- same module main.lua and DebugOverlay read for their mobile gates,
+-- which resolves the OS name inside engine code. This wrapper exists so
+-- platform policy in MeshCache / ChunkMesher stays readable and
+-- testable: tests swap the OS the engine module answers (an OS-name
+-- stub plus the engine module's test reset) exactly as the suite does.
+--
+-- Only the Switch (NX) answer is exported today. The cache fixes that
+-- gate on it exist because the observed failures -- storage deletes that
+-- silently no-op, a second boot-time Assets handoff, a zlib-only
+-- compress chain -- are Switch-port facts, and desktop builds must keep
+-- their historical behavior byte for byte. (No OS API is named here;
+-- the engine answers NX when the console reports itself as such.)
+
+local P = {}
+
+local function enginePlatform()
+  local ok, Engine = pcall(require, "src.core.Platform")
+  if not ok or type(Engine) ~= "table" then return nil end
+  return Engine
+end
+
+function P.isSwitch()
+  local Engine = enginePlatform()
+  if not Engine then return false end
+  local okI, isNX = pcall(Engine.isNX)
+  if okI and type(isNX) == "boolean" then return isNX end
+  local okD, info = pcall(Engine.detect)
+  if not okD or type(info) ~= "table" then return false end
+  return not not info.nx
+end
+
+-- Tests swap the OS the engine module answers between cases; the engine
+-- module caches its answer, so the reset is forwarded for symmetry with
+-- the engine API.
+function P._resetForTests()
+  local Engine = enginePlatform()
+  if Engine and Engine._resetForTests then
+    pcall(Engine._resetForTests)
+  end
+end
+
+return P

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -39,6 +39,11 @@ local function withOS(osName, fn)
   EnginePlatform._resetForTests()
   local ok, err = pcall(fn)
   EnginePlatform._resetForTests()
+  -- Restore the shim's real getOS: _G.love is the SDK's SHARED love
+  -- table, so mutating it in place and only restoring the reference
+  -- leaks the stub to every later test (a leaked "NX" flipped the
+  -- off-Switch codec assertions on CI).
+  _G.love.system.getOS = oldOS
   _G.love = oldLove
   if not ok then error(err, 0) end
 end
@@ -597,10 +602,10 @@ end
 
 withOS("OS X", function()
   freshManifestCache()
-  Assets.invalidate()   -- callback 1: the boot handoff, skipped by design
-  T.check(not manifestGone(), "desktop: first handoff keeps the manifest")
-  Assets.invalidate()   -- callback 2: a real invalidation off-Switch
-  T.check(manifestGone(), "desktop: second handoff drops the manifest")
+  Assets.invalidate()   -- the boot handoff (or a later one: loadMod may
+  Assets.invalidate()   -- have fired the engine's handoff already)
+  T.check(manifestGone(),
+          "desktop: invalidations land once the boot handoff is past")
 end)
 
 withOS("NX", function()
@@ -608,7 +613,7 @@ withOS("NX", function()
   Assets.invalidate()
   Assets.invalidate()   -- the observed double boot handoff
   T.check(not manifestGone(),
-          "Switch: double boot handoff must keep the manifest")
+          "Switch: boot-time invalidations must keep the manifest")
   ChunkMesher.request(fakeMap, true, {}, false, true)
   Assets.invalidate()
   T.check(manifestGone(),

--- a/tests/potato_voxel_cache_test.lua
+++ b/tests/potato_voxel_cache_test.lua
@@ -19,9 +19,29 @@ local fakeGame = { save = { options = optionsState },
                    writeOptions = function() end }
 local Prebuild = exports.lib.require("CachePrebuild")
 local MeshCache = exports.lib.require("MeshCache")
+local ChunkMesher = exports.lib.require("ChunkMesher")
 local Brick = exports.brick
 local Battles = exports.lib.require("OverworldBattle")
 local QualityMode = exports.lib.require("QualityMode")
+
+-- Platform switching for the Switch-gated cache fixes: stub the OS the
+-- engine Platform module answers, exactly like the main suite does, and
+-- restore afterwards. The mod's own Platform wrapper has no state of its
+-- own (it forwards to the engine module), so only the engine cache needs
+-- the reset.
+local EnginePlatform = require("src.core.Platform")
+local function withOS(osName, fn)
+  local oldLove = _G.love
+  _G.love = oldLove or {}
+  _G.love.system = _G.love.system or {}
+  local oldOS = _G.love.system.getOS
+  _G.love.system.getOS = function() return osName end
+  EnginePlatform._resetForTests()
+  local ok, err = pcall(fn)
+  EnginePlatform._resetForTests()
+  _G.love = oldLove
+  if not ok then error(err, 0) end
+end
 
 if Brick and Brick.isBrick() then
   T.eq(Brick.battleRenderScale(), 1.0,
@@ -209,6 +229,41 @@ if MeshCache.available() then
           and fakeStore.peekBytes()["maps/A/body/aux"] == nil,
           "wipe cache removes all payload variants")
 
+  -- --- Switch: a wipe that does not land is reported, not swallowed -----
+  -- The Switch-port logs showed deletes no-oping while reporting
+  -- success: after WIPE CACHE the prebuild restarted from zero (manifest
+  -- and metas gone) yet the old payloads kept serving cache hits. On
+  -- Switch the wipe verifies by read-back and answers false (plus a
+  -- storage-fail count) when keys survive; every other platform keeps
+  -- the historical fire-and-forget behavior.
+  local realDelete = fakeStore.delete
+  fakeStore.delete = function() return true end   -- a delete that no-ops
+  MeshCache.saveTerrain(fakeMap, "body", nil, 0)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  withOS("OS X", function()
+    T.check(MeshCache.wipe({ { id = "A", slot = "body" } }),
+            "off-Switch: wipe behavior unchanged when delete no-ops")
+    T.check(fakeStore.peekBytes()["maps/A/body/terrain"] ~= nil,
+            "off-Switch: surviving payload is not the wipe's problem")
+  end)
+  MeshCache.saveTerrain(fakeMap, "body", nil, 0)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  withOS("NX", function()
+    T.check(not MeshCache.wipe({ { id = "A", slot = "body" } }),
+            "Switch: wipe reports false when keys survive delete")
+    T.check(fakeStore.peekBytes()["maps/A/body/terrain"] ~= nil,
+            "Switch: surviving payload kept (delete really no-oped)")
+  end)
+  fakeStore.delete = realDelete
+  withOS("NX", function()
+    T.check(MeshCache.wipe({ { id = "A", slot = "body" } }),
+            "Switch: wipe reports true when delete actually lands")
+    T.check(fakeStore.peekBytes()["maps/A/body/terrain"] == nil,
+            "Switch: clean wipe removes the payloads")
+  end)
+
   local oldLove = love
   local testLove = oldLove or {}
   local oldData = testLove.data
@@ -300,6 +355,47 @@ if MeshCache.available() then
           "zlib cache reports READY from summaries")
   T.eq(MeshCache.codec(), "zlib",
        "cache status identifies the zlib codec")
+
+  -- --- Switch: lz4 preferred over zlib when zstd is absent --------------
+  -- The Switch-port logs showed the same prebuild tail running ~2x
+  -- faster with lz4 (codec lz4 manifest) than with zlib (codec zlib
+  -- manifest). With both zlib and lz4 available and no zstd, desktop
+  -- keeps the zlib preference; on Switch packPayload must pick lz4.
+  local function codecByte(bytes)
+    if not bytes then return nil end
+    return bytes:byte(9 + (bytes:byte(5) + bytes:byte(6) * 256
+                           + bytes:byte(7) * 65536
+                           + bytes:byte(8) * 16777216))
+  end
+  testLove.data.compress = function(_, format, body)
+    if format ~= "zlib" and format ~= "lz4" then return nil end
+    serial = serial + 1
+    local key = "dual" .. serial
+    packed[key] = body
+    return key
+  end
+  MeshCache.saveTerrain(fakeMap, "body", vertices, 128)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  T.eq(codecByte(fakeStore.peekBytes()["maps/A/body/terrain"]), 3,
+       "off-Switch: zlib still wins over lz4 when both are available")
+  T.check(MeshCache.ready({ { id = "A", slot = "body" } }),
+          "dual-codec cache reports READY (off-Switch)")
+  T.eq(MeshCache.codec(), "zlib",
+       "off-Switch: codec status stays zlib")
+  MeshCache.wipe({ { id = "A", slot = "body" } })
+  withOS("NX", function()
+    MeshCache.saveTerrain(fakeMap, "body", vertices, 128)
+    MeshCache.saveWater(fakeMap, "body", nil, 0)
+    MeshCache.saveAux(fakeMap, "body", { figures = {} })
+    T.eq(codecByte(fakeStore.peekBytes()["maps/A/body/terrain"]), 1,
+         "Switch: lz4 preferred over zlib when zstd is absent")
+    T.check(MeshCache.ready({ { id = "A", slot = "body" } }),
+            "dual-codec cache reports READY (Switch)")
+    T.eq(MeshCache.codec(), "lz4",
+         "Switch: codec status identifies lz4")
+    MeshCache.wipe({ { id = "A", slot = "body" } })
+  end)
 
   testLove.data = oldData
   _G.love = oldLove
@@ -476,6 +572,48 @@ if MeshCache.available() then
     MeshCache.wipe(jobSet)
   end
 end
+
+-- --- Switch: the boot-time Assets handoff must not drop the manifest ----
+-- The port logs showed "cache invalidate ALL" 18ms after boot, before
+-- save.created: the engine's installLoader -> Assets.invalidate handoff
+-- fired twice, and the second call dropped the manifest, forcing a cold
+-- 444-job prebuild on every launch. On Switch, handoff invalidations
+-- are ignored until the first mesh entry exists; desktop keeps the
+-- historical second-call behavior.
+local Assets = require("src.render.Assets")
+local function freshManifestCache()
+  MeshCache.configure({ maps = maps, tilesets = {} })
+  MeshCache.begin()
+  MeshCache.saveTerrain(fakeMap, "body", nil, 0)
+  MeshCache.saveWater(fakeMap, "body", nil, 0)
+  MeshCache.saveAux(fakeMap, "body", { figures = {} })
+  local rec = MeshCache.jobRecord(fakeMap, "body")
+  T.check(MeshCache.writeManifest({ [rec.key] = rec }, 1),
+          "handoff test: manifest written")
+end
+local function manifestGone()
+  return fakeStore.peekTables().manifest == nil
+end
+
+withOS("OS X", function()
+  freshManifestCache()
+  Assets.invalidate()   -- callback 1: the boot handoff, skipped by design
+  T.check(not manifestGone(), "desktop: first handoff keeps the manifest")
+  Assets.invalidate()   -- callback 2: a real invalidation off-Switch
+  T.check(manifestGone(), "desktop: second handoff drops the manifest")
+end)
+
+withOS("NX", function()
+  freshManifestCache()
+  Assets.invalidate()
+  Assets.invalidate()   -- the observed double boot handoff
+  T.check(not manifestGone(),
+          "Switch: double boot handoff must keep the manifest")
+  ChunkMesher.request(fakeMap, true, {}, false, true)
+  Assets.invalidate()
+  T.check(manifestGone(),
+          "Switch: invalidation lands once mesh work has started")
+end)
 
 run.release()
 T.finish("potato_voxel_cache")

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -440,11 +440,17 @@ if brick then
       box.opts.choice(true)
     end
     -- Without a send capability the export must never ask: the local
-    -- dump is the whole action there.
+    -- dump is the whole action there. The engine loader now provides
+    -- mod.postLog unconditionally, so this sub-case clears both the
+    -- transport and the manifest's log_url explicitly.
+    local noSendPostLog, noSendManifest = mod.postLog, mod.manifest
+    mod.postLog = nil
+    mod.manifest = nil
     T.check(not DebugOverlay.canSend(),
             "no postLog or log_url means nothing can be sent")
     DebugOverlay.export(consentGame)
     T.check(stackPushed == nil, "a local-only export does not prompt")
+    mod.postLog, mod.manifest = noSendPostLog, noSendManifest
     mod.postLog = function(_, body) sends = sends + 1 lastBody = body return true end
     mod.manifest = { log_url = "https://logs.example.invalid/logs" }
     T.check(DebugOverlay.canSend(),


### PR DESCRIPTION
### Cache (Switch)

- Platform detection: the mod now answers "is this the Switch port?"
  through a small wrapper (`lib/Platform.lua`) over the engine's own
  Platform module (the NX flag -- the sandbox forbids the mod touching
  love.system itself). Every Switch-only cache change below gates on it;
  desktop and other platforms run exactly as before.
- Compression codec: on Switch, `packPayload` now prefers lz4 over zlib
  when zstd is absent. zlib's compress is a multi-hundred-ms main-thread
  stall per big payload, and the Switch-port logs showed the same
  prebuild tail running ~2x faster with lz4 than with zlib (zlib vs lz4
  manifests). The quantized payloads lose little ratio, so the faster
  codec wins on the console; elsewhere the chain stays zstd -> zlib ->
  lz4.
- WIPE CACHE now verifies on Switch: after deleting, the wipe read-backs
  the manifest/buildinfo and re-lists both payload namespaces, counts
  every survivor as a storage failure, and reports false instead of
  claiming success. The Switch storage has been observed to no-op
  deletes while reporting success -- after a wipe the prebuild restarted
  from zero (manifest/metas gone) while the old payloads kept serving
  cache hits.
- Boot invalidation: on Switch, the engine's Assets.installLoader ->
  Assets.invalidate handoff has been observed to fire twice at boot; the
  second call dropped the manifest and forced a cold 444-job prebuild on
  every launch. Handoff invalidations are now ignored until the first
  mesh entry exists (which a boot-time handoff can never be), so Switch
  restarts stay warm; real invalidations still land the moment any mesh
  work starts.
- `deleteKey` now returns the storage call's real result instead of
  swallowing it; no caller's behavior changes off-Switch.

All suites pass headless: cache 78/78, main 206/206, sandbox scan clean,
loading suite ok, modkit lint + validate ok.
