### PR TITLE
Fix iOS shadow canvas format

### DIFF
--- a/lib/PixelCanvas.lua
+++ b/lib/PixelCanvas.lua
@@ -2,9 +2,15 @@ local V = ...
 
 local PixelCanvas = {}
 
-function PixelCanvas.new(w, h)
+-- `format` is optional because most scene canvases should keep the engine's
+-- normal color format. Packed numeric render targets (shadow depth, for
+-- example) must opt into a non-sRGB format so gamma conversion cannot change
+-- the values written by a shader and later sampled as data.
+function PixelCanvas.new(w, h, format)
+  local settings = { dpiscale = 1 }
+  if format then settings.format = format end
   local ok, canvas = pcall(love.graphics.newCanvas, w, h,
-                           { dpiscale = 1 })
+                           settings)
   if ok then return canvas ~= nil, canvas, canvas and nil or "newCanvas returned nil" end
   return false, nil, tostring(canvas)
 end

--- a/lib/Platform.lua
+++ b/lib/Platform.lua
@@ -8,12 +8,11 @@
 -- testable: tests swap the OS the engine module answers (an OS-name
 -- stub plus the engine module's test reset) exactly as the suite does.
 --
--- Only the Switch (NX) answer is exported today. The cache fixes that
--- gate on it exist because the observed failures -- storage deletes that
--- silently no-op, a second boot-time Assets handoff, a zlib-only
--- compress chain -- are Switch-port facts, and desktop builds must keep
--- their historical behavior byte for byte. (No OS API is named here;
--- the engine answers NX when the console reports itself as such.)
+-- Switch (NX) and iOS answers are exported. The cache fixes gate on Switch
+-- because the observed failures there are port-specific, while the packed
+-- shadow canvas has an iOS-only color-pipeline workaround. Other platforms
+-- keep their historical behavior byte for byte. (No OS API is named here;
+-- the engine answers both facts.)
 
 local P = {}
 
@@ -31,6 +30,13 @@ function P.isSwitch()
   local okD, info = pcall(Engine.detect)
   if not okD or type(info) ~= "table" then return false end
   return not not info.nx
+end
+
+function P.isIOS()
+  local Engine = enginePlatform()
+  if not Engine then return false end
+  local ok, info = pcall(Engine.detect)
+  return ok and type(info) == "table" and info.os == "iOS"
 end
 
 -- Tests swap the OS the engine module answers between cases; the engine

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -30,6 +30,8 @@ local V = ...
 local Mat4 = V.require("Mat4")
 local Voxel = V.require("VoxelState")
 local ShadowSettings = V.require("ShadowSettings")
+local Platform = V.require("Platform")
+local PixelCanvas = V.require("PixelCanvas")
 
 local ShadowMap = {}
 
@@ -243,6 +245,11 @@ local passCounts = { begins = 0, finishes = 0, aborts = 0 }
 -- are optional in GLES; probing the actual canvas is the capability test.
 local DEPTH_FORMATS = { "depth24", "depth24stencil8", "depth32f", "depth16" }
 
+local function shadowColorFormat()
+  local ok, ios = pcall(Platform.isIOS)
+  return ok and ios and "rgba8" or nil
+end
+
 local IDENTITY = Mat4.identity()
 
 -- world -> [0,1] cube, applied on top of the clip matrix: the main pass
@@ -410,7 +417,11 @@ local function getCanvas(res)
     getDepthCanvas(res)
     return canvas
   end
-  local ok, c, err = V.require("PixelCanvas").new(res, res)
+  -- iOS/Metal's gamma-correct color path can alter the packed depth bytes.
+  -- Keep the workaround platform-scoped; every other platform retains the
+  -- historical default color canvas while all targets keep dpiscale = 1.
+  local format = shadowColorFormat()
+  local ok, c, err = PixelCanvas.new(res, res, format)
   if not (ok and c) then
     canvasError = err or "newCanvas returned nil"
     canvas = false
@@ -428,7 +439,7 @@ local function getCanvas(res)
     pcall(spriteCanvas.release, spriteCanvas)
   end
   if ShadowMap.SPRITE_LAYER then
-    local okS, sc, errS = V.require("PixelCanvas").new(res, res)
+    local okS, sc, errS = PixelCanvas.new(res, res, format)
     if okS and sc then
       spriteCanvasError = nil
       sc:setFilter("nearest", "nearest")

--- a/tests/shadow_cadence_probe.lua
+++ b/tests/shadow_cadence_probe.lua
@@ -51,6 +51,12 @@ local V = {
     if name == "Mat4" then return Mat4 end
     if name == "VoxelState" then return Voxel end
     if name == "ShadowSettings" then return ShadowSettings end
+    if name == "Platform" then
+      return { isIOS = function() return false end }
+    end
+    if name == "PixelCanvas" then
+      return assert(loadfile(root .. "/lib/PixelCanvas.lua"))(V)
+    end
     error("probe: unexpected require " .. tostring(name))
   end,
 }

--- a/tests/shadow_golden.lua
+++ b/tests/shadow_golden.lua
@@ -31,6 +31,12 @@ local V = {
     if name == "Mat4" then return Mat4 end
     if name == "VoxelState" then return Voxel end
     if name == "ShadowSettings" then return ShadowSettings end
+    if name == "Platform" then
+      return { isIOS = function() return false end }
+    end
+    if name == "PixelCanvas" then
+      return assert(loadfile(root .. "/lib/PixelCanvas.lua"))(V)
+    end
     error("golden: unexpected require " .. tostring(name))
   end,
 }

--- a/tests/shadow_runtime_test.lua
+++ b/tests/shadow_runtime_test.lua
@@ -20,6 +20,9 @@ end
 
 local bound = nil
 local binds = {}
+local canvasKinds = {}
+local canvasFormats = {}
+local ios = true
 local rejectExplicit = false
 local rejectImplicit = true
 local oldLove = _G.love
@@ -27,8 +30,10 @@ _G.love = { graphics = {} }
 local g = _G.love.graphics
 
 function g.newCanvas(w, h, opts)
+  canvasKinds[#canvasKinds + 1] = opts and opts.format or "default"
   if opts and opts.format then
-    if rejectExplicit then
+    canvasFormats[#canvasFormats + 1] = opts.format
+    if rejectExplicit and opts.format ~= "rgba8" then
       error("explicit depth format rejected by test backend")
     end
     return canvas(w, h, opts.format)
@@ -61,6 +66,9 @@ local V = {
     if name == "Mat4" then return Mat4 end
     if name == "VoxelState" then return Voxel end
     if name == "ShadowSettings" then return ShadowSettings end
+    if name == "Platform" then
+      return { isIOS = function() return ios end }
+    end
     if name == "PixelCanvas" then
       return assert(loadfile(root .. "/lib/PixelCanvas.lua"))(V)
     end
@@ -81,6 +89,8 @@ local function check(condition, name)
 end
 
 check(ShadowMap.available(), "shadow capability accepts explicit depth target")
+check(canvasFormats[1] == "rgba8" and canvasFormats[2] == "rgba8",
+      "packed shadow layers use a raw rgba8 canvas format")
 check(ShadowMap.begin(0, 0, 160, 144, false),
       "world pass begins when implicit depth binding is unavailable")
 local worldDiagnostics = ShadowMap.diagnostics()
@@ -117,6 +127,19 @@ check(ShadowMap.diagnostics().depth.binding == "internal",
 ShadowMap.finish("world-fallback", false)
 check(ShadowMap.diagnostics().worldReady,
       "internal depth fallback produces a ready world layer")
+
+-- Non-iOS platforms retain the historical default color canvas. Only iOS
+-- needs the explicit raw format because that is where the packed depth was
+-- observed being altered by the display color pipeline.
+ShadowMap.invalidate()
+ios = false
+rejectExplicit = false
+rejectImplicit = false
+local beforeNonIOS = #canvasKinds
+check(ShadowMap.available(), "non-iOS shadow capability remains available")
+check(canvasKinds[beforeNonIOS + 1] == "default"
+      and canvasKinds[beforeNonIOS + 2] == "default",
+      "non-iOS shadow layers keep the default canvas format")
 
 _G.love = oldLove
 io.write(("shadow runtime: %d passed, %d failed\n"):format(passed, failed))


### PR DESCRIPTION
## Summary

- Scope the packed shadow canvas format workaround to iOS/Metal only.
- Preserve the historical default canvas format on Switch and other platforms.
- Keep `dpiscale = 1` for shadow canvases on every platform.

## Validation

- `luajit tests/shadow_runtime_test.lua`
- `luajit tests/shadow_cadence_probe.lua`
- `luajit tests/shadow_golden.lua`
- `luajit tests/sandbox_api_test.lua`
- `luajit tests/voxel_loading_test.lua`
- `git diff HEAD^ --check`
