### PR TITLE
WorkerPool: gate on BrickProfile, and pin the gate with a test

### DIFF
--- a/lib/WorkerPool.lua
+++ b/lib/WorkerPool.lua
@@ -87,9 +87,8 @@ end
 function WorkerPool.enabled()
   local platform = platformInfo()
   if platform.mobile or platform.nx or platform.web then return false end
-  local okBrick = pcall(V.require, "Brick")
   local ok, brick = pcall(function()
-    local B = V.require("Brick")
+    local B = V.require("BrickProfile")
     return B and B.isBrick and B.isBrick()
   end)
   if ok and brick then return false end

--- a/tests/cache_stream_contract_test.lua
+++ b/tests/cache_stream_contract_test.lua
@@ -480,7 +480,7 @@ do
       if name == "DiagnosticsBridge" then
         return { note = function() end, warn = function() end }
       end
-      if name == "Brick" then
+      if name == "BrickProfile" then
         return { isBrick = function() return false end }
       end
       error("unexpected worker dependency: " .. tostring(name))
@@ -492,6 +492,34 @@ do
         "mobile geometry workers must stay disabled")
   check(mobilePool.workerCount() == 0,
         "mobile geometry worker count must be zero")
+
+  -- The brick gate, on a platform that would otherwise take workers. Every
+  -- other fixture answers isBrick() == false, so the gate's own branch is
+  -- never entered and a gate that cannot fire at all still passes: a require
+  -- of a module that does not exist throws, the pcall swallows it, and the
+  -- result is indistinguishable from "not a brick". Pin isBrick() == true so
+  -- the disable path is exercised.
+  package.loaded["src.core.Platform"] = {
+    detect = function() return {} end,
+  }
+  local brickV = {
+    require = function(name)
+      if name == "MeshCache" then return { GEOMETRY_VERSION = 27 } end
+      if name == "ChunkMesher" or name == "GeometrySnapshot" then return {} end
+      if name == "DiagnosticsBridge" then
+        return { note = function() end, warn = function() end }
+      end
+      if name == "BrickProfile" then
+        return { isBrick = function() return true end }
+      end
+      error("unexpected worker dependency: " .. tostring(name))
+    end,
+    mod = {},
+  }
+  local brickPool = assert(loadfile("lib/WorkerPool.lua"))(brickV)
+  check(not brickPool.enabled(),
+        "brick profile geometry workers must stay disabled")
+
   package.loaded["src.core.Platform"] = oldPlatform
   _G.love = oldLove
 end


### PR DESCRIPTION
Rebased onto current `main` (1.8.0's `WorkerPool` rewrite). The bug survived that rewrite — the new platform checks were added around it, but both `"Brick"` requires came along unchanged.

## The problem

`WorkerPool.enabled()` gates the threaded prebuild on the brick profile:

```lua
local okBrick = pcall(V.require, "Brick")
local ok, brick = pcall(function()
  local B = V.require("Brick")
  return B and B.isBrick and B.isBrick()
end)
if ok and brick then return false end
```

There is no `Brick` module — it is `BrickProfile`. `lib/Brick.lua` was renamed well before the worker pool arrived in 1.7.8, so this require has always thrown, the `pcall` swallows it, `ok` is `false`, and the branch never fires.

So the gate has never worked, and the comment above it — *"NX/web and Brick retain their compatibility paths"* — is not true for Brick. These are the only two `"Brick"` references in the tree; `BattleScene.lua`, `MeshCache.lua` and `VoxelScene.lua` already use `BrickProfile`.

## Why no test caught it

The worker fixture answers the **wrong name too**:

```lua
if name == "Brick" then
  return { isBrick = function() return false end }
end
```

It was written against the typo. And because every fixture in the suite pins `isBrick() == false`, the gate's own branch is never entered — so a gate that *cannot* fire is indistinguishable from one that decides not to:

| | `V.require("BrickProfile")` | `V.require("Brick")` |
|---|---|---|
| require | returns the mock | throws, `pcall` catches |
| `brick` | `false` | `nil` |
| `if ok and brick` | doesn't fire | doesn't fire |
| workers | enabled | enabled |

Identical result, so the suite is structurally blind to it.

This PR corrects the fixture's module name and adds a case on a platform that would otherwise take workers, with `isBrick() == true`, so the disable path is actually exercised.

**That case fails against the current `WorkerPool` and passes with the fix** — verified both ways locally (`cache stream contract tests: PASS` with the fix; the new check errors without it).

## Observed

RG35XXSP (1 GB, quad A53, Mali-G31), brick profile. Before the fix, a prebuild of two missing jobs:

```
geometry workers: 2 threads
prebuild start: 0/444 done, 444 jobs
prebuild 443/444 done ROUTE_22/body (worker)
prebuild 444/444 done ROUTE_22/full (worker)
prebuild 445/444 done ROUTE_22_GATE/body (worker)
```

The counter runs past the total and the build ends in `MAP CACHE FAILED`. With the gate firing, the same prebuild completes serially:

```
prebuild 444/444 done VIRIDIAN_CITY/full
```

I have not touched the threaded path itself — the `445/444` miscount looks worth a separate look, but on this hardware the gate firing is what the code already intends.
