### PR TITLE
fix: voxel mode flickering between 2D and 3D (BUG-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.8.2] - 2026-08-19
+
+### Fixed: voxel mode flickering between 2D and 3D (BUG-3)
+
+- Fixed stallSkip oscillation loop in `WorldFeature.lua`: consecutive GPU hitches (>250ms) no longer cause rapid 2D/3D render flapping because the skip state is now preserved until the 4-frame skip window fully elapses.
+- Removed OFF (level 0) from `Voxel.HOTKEY_ORDER` in `VoxelState.lua`: pressing Shift/8 no longer cycles into 2D mode, preventing desktop players who use Shift to sprint from inadvertently toggling voxel mode off.
+- Allowed camera tween to progress behind loading cover in `VoxelState.lua`: eliminates the 1-2 frame flat camera flash on map warp transitions.
+- Added post-backgrounding drawWorld watchdog in `main.lua`: detects when the engine stops issuing draw calls while overworld voxel rendering is active on Android and forces a pipeline invalidation to re-engage rendering.
+
 ## [1.7.12] - 2026-08-17
 
 ### Fixed: precache memory growth and sprite regression

--- a/lib/VoxelState.lua
+++ b/lib/VoxelState.lua
@@ -91,7 +91,7 @@ end
 -- which is exactly what the key promises -- and the key is also the way back
 -- OUT of them on a keyboard, where the mouse is captured and the OPTIONS
 -- menu is a trip.
-Voxel.HOTKEY_ORDER = { 0, 2, 3, 4, 5, 6, 7 }  -- OFF,15,35,50,75,1ST,3RD
+Voxel.HOTKEY_ORDER = { 2, 3, 4, 5, 6, 7 }  -- 15,35,50,75,1ST,3RD (OFF via settings only)
 
 -- The rung a press moves to from `level`.
 --
@@ -204,8 +204,11 @@ end
 function Voxel.update(dt, level)
   if level ~= nil and level ~= Voxel.level then Voxel.setLevel(level) end
   -- hold at flat until there is geometry to tilt over; easing OUT (goal
-  -- below the current angle) never waits
-  if Voxel.angle == 0 and Voxel.goal > 0 and not Voxel.ready then
+  -- below the current angle) never waits.  When a loading cover is active
+  -- the cover hides the empty stage, so the tween advances behind it and
+  -- the camera is already at the goal angle when the cover lifts (BUG-3).
+  if Voxel.angle == 0 and Voxel.goal > 0 and not Voxel.ready
+     and not Voxel.loading then
     return
   end
   if Voxel.t < 1 then

--- a/lib/WorldFeature.lua
+++ b/lib/WorldFeature.lua
@@ -25,6 +25,11 @@ WorldFeature.STALL_TRIGGER = 2
 WorldFeature.STALL_MAX_FRAMES = 4
 
 function WorldFeature.updateStall(dt, stallSkip)
+  -- While actively skipping frames, preserve the armed state so the
+  -- full skip window completes before voxel re-engages.  The fast 2D
+  -- fallback frames during a skip are not evidence of GPU recovery --
+  -- resetting here caused a single-frame oscillation loop (BUG-3).
+  if stallSkip.frames > 0 then return end
   stallSkip.count = dt > WorldFeature.STALL_FRAME
     and (stallSkip.count + 1) or 0
   if stallSkip.count == 0 then stallSkip.frames = 0 end

--- a/main.lua
+++ b/main.lua
@@ -200,7 +200,8 @@ local renderMs = 0
 -- scene render, and the periods where voxel is inactive (drawWorld never
 -- runs at all).
 local worldDiag = { loadingEntered = 0, loadingReported = false,
-                    inactiveNoted = false, firstRender = false }
+                    inactiveNoted = false, firstRender = false,
+                    drawStaleTicks = 0 }
 
 -- Entry-frame work deferred off the frame that queued it (BUG-2c): a
 -- non-urgent options write must not ride the restoreSave frame -- the
@@ -434,6 +435,24 @@ mod.content.render_pipelines:register("voxel", {
     -- Deck log's 4s frames) arm the render-skip in drawWorld below.
     WorldFeature.updateStall(dt, stallSkip)
     local covered = Game and Game.stack and Game.stack:top() ~= ow
+    -- BUG-3 watchdog: after an extended app backgrounding the engine can
+    -- stop calling drawWorld despite the pipeline being active.  When the
+    -- overworld is uncovered and voxel is active, count update ticks since
+    -- the last draw call.  120 ticks (~2 s at 60 fps) with no draw while
+    -- uncovered triggers a pipeline invalidation to re-engage the engine.
+    if covered then
+      worldDiag.drawStaleTicks = 0
+    else
+      worldDiag.drawStaleTicks = worldDiag.drawStaleTicks + 1
+      if worldDiag.drawStaleTicks >= 120 then
+        DebugOverlay.error(
+          "drawWorld stale for %d ticks while active; forcing invalidation",
+          worldDiag.drawStaleTicks)
+        Voxel3D.invalidate()
+        ChunkMesher.invalidate()
+        worldDiag.drawStaleTicks = 0
+      end
+    end
     -- The shared queue pumps with CachePrebuild's own slice budget while
     -- a prebuild runs (BUG-2a): the queue is shared, so the live pump
     -- would otherwise slurp prebuild jobs at the full covered slice.
@@ -448,6 +467,7 @@ mod.content.render_pipelines:register("voxel", {
   end,
 
   drawWorld = function(ctx)
+    worldDiag.drawStaleTicks = 0
     local ok, result = DebugOverlay.try("voxel-drawWorld", function()
       local canvas, elapsed = WorldFeature.render(ctx, worldDiag, stallSkip)
       if elapsed ~= nil then renderMs = elapsed end
@@ -798,7 +818,7 @@ mod.hooks:wrap("world.tod", function(next, tod, ctx)
   return DayNight.tod()
 end)
 
-mod.exports.version = "1.7.12"
+mod.exports.version = "1.8.2"
 -- exposed so a companion mod can pin its own tiles' shapes or read the
 -- camera without reaching into this mod's file layout
 mod.exports.lib = V

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.7.12",
+  "version": "1.8.2",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -7,7 +7,7 @@ local run = T.sdk.loadMod("mods/potato_voxel", { data = Data })
 T.eq(#run.errors, 0, "loads clean")
 local exports = run.loader.exports.potato_voxel
 T.check(exports ~= nil, "mod exports a table")
-T.eq(exports.version, "1.7.12", "exports the manifest release version")
+T.eq(exports.version, "1.8.2", "exports the manifest release version")
 for _, name in ipairs({
   "Horde", "HordeGun", "HordeHud", "HordeMobs", "HordeSfx",
   "HordeExitPrompt", "HordeGameOver",


### PR DESCRIPTION
## Summary

Fixes voxel mode randomly flickering between the standard 2D renderer and the Voxel 3D pipeline. Root causes were identified from analysis of 120+ telemetry log sessions (`1_08_01` / Mod v1.8.1) across all platforms (Android, Windows, macOS, Linux).

## Root Causes & Fixes

### 1. `stallSkip` oscillation feedback loop — `WorldFeature.lua`
When 2 consecutive frames exceeded 250ms, `drawWorld` returned `nil` for up to 4 frames (2D fallback). But the fast 2D frames immediately reset `stallSkip.count`, causing voxel to re-engage on the very next frame — and if the GPU was still loaded, it hitched again, producing a rapid 2D↔3D oscillation every 2–6 frames.

**Fix:** Freeze the stall counter while actively skipping (`stallSkip.frames > 0`), so the full 4-frame skip window completes before voxel re-engages.

### 2. Shift key cycling through OFF — `VoxelState.lua`
`HOTKEY_ORDER` included level `0` (OFF), so every 7th Shift/8 press dropped the renderer to 2D. Desktop players using Shift to sprint triggered this constantly (Windows logs showed 25 level changes in 10 seconds).

**Fix:** Remove `0` from `HOTKEY_ORDER`. OFF remains accessible via the settings menu. Pressing the hotkey from OFF jumps to the first active rung (15°).

### 3. Map transition flat-camera flash — `VoxelState.lua`
On map transitions, the loading cover hid the view, but the camera tween was also held flat at 0° waiting for `Voxel.ready`. When terrain landed and loading lifted, the camera started tweening from 0° — producing a 1–2 frame flat flash.

**Fix:** Allow the tween to advance while the loading cover is active (`and not Voxel.loading`), so the camera is already at the goal angle when terrain lands.

### 4. Post-background `drawWorld` disconnect — `main.lua`
On Android, after extended app backgrounding (6,000+ seconds observed), the engine stopped calling `drawWorld` entirely despite the pipeline reporting active. Updates kept ticking but draws froze — one session showed draws stuck at 1,232 for 11 minutes (14,496 frames).

**Fix:** Add a lightweight watchdog that tracks update ticks since the last `drawWorld` call. When voxel is active, the overworld is uncovered, and draws have been stale for 120+ ticks (~2s), force a pipeline invalidation to re-engage the engine.

## Testing
- ✅ `voxel_loading_test.lua` — pass
- ✅ `shadow_cadence_probe.lua` — 8,976 passed, 0 failed
- ✅ `shadow_golden.lua` — 66 passed, 0 failed
- ✅ `sandbox_api_test.lua` — clean

## Changes
- `lib/WorldFeature.lua` — 5 lines added (stallSkip guard)
- `lib/VoxelState.lua` — 6 lines added, 3 removed (hotkey order + loading tween)
- `main.lua` — 21 lines added, 1 removed (watchdog state + check + drawWorld reset)