### PR TITLE
Fix Sprites bigger than 16x16

### DIFF
--- a/lib/SpriteBillboards.lua
+++ b/lib/SpriteBillboards.lua
@@ -14,6 +14,12 @@
 -- art. One quad wearing the real frame is both more faithful and cheaper:
 -- it needs no pixel access at all, only the sheet's dimensions.
 --
+-- Vanilla figures all read that dimension as a fixed 16, but a mod's
+-- registered sprite (furniture, decor placed as an overworld entity) can
+-- carry its own frameWidth/frameHeight the 2D path already honours -- see
+-- buildCard below. The card stays a flat drawing either way; only its
+-- size changes.
+--
 -- The card always faces SOUTH -- the direction the 2D game implies -- and
 -- only LEANS BACK, pivoting at its feet, by exactly the camera's pitch
 -- (VoxelScene's billboardMatrix), so at every tilt level it reads face-on
@@ -32,20 +38,33 @@ local SpriteBillboards = {}
 
 local meshes = {}
 
--- One flat 16x16 quad UV-mapped to a whole frame. A hair of inset keeps
--- the sampler inside this frame rather than picking up the neighbouring
--- one along the shared edge.
+-- One flat quad -- 16x16 for every vanilla figure, or the def's own
+-- frameWidth x frameHeight for a mod sprite registered bigger than that --
+-- UV-mapped to a whole frame. A hair of inset keeps the sampler inside
+-- this frame rather than picking up the neighbouring one along the shared
+-- edge.
+--
+-- billboardMatrix and Voxel3D.casterMatrix both pivot the finished card at
+-- its feet by translating to the entity's tile centre and then shifting
+-- -8 (half of the vanilla 16px width) so the card ends up centred over the
+-- tile. That shift is fixed and shared by every entity, so a wider card
+-- bakes its OWN half-width in here (x0 = 8 - fw / 2) rather than asking
+-- the shared matrices to know each sprite's size -- for fw == 16 that is
+-- x0 = 0, the original quad, unchanged.
 local function buildCard(def, frame)
   local ok, img = pcall(Assets.image, def.image)
   if not (ok and img) then return nil end
   local iw, ih = img:getDimensions()
-  local fy = frame * 16
-  if fy + 16 > ih then fy = 0 end
-  local u0, u1 = 0.02 / iw, (16 - 0.02) / iw
-  local v0, v1 = (fy + 0.05) / ih, (fy + 15.95) / ih
+  local fw = def.frameWidth or 16
+  local fh = def.frameHeight or 16
+  local fy = frame * fh
+  if fy + fh > ih then fy = 0 end
+  local u0, u1 = 0.02 / iw, (fw - 0.02) / iw
+  local v0, v1 = (fy + 0.05) / ih, (fy + fh - 0.05) / ih
+  local x0, x1 = 8 - fw / 2, 8 + fw / 2
   local verts = {
-    { 0, 0, 0, u0, v1, 1 }, { 16, 0, 0, u1, v1, 1 },
-    { 16, 16, 0, u1, v0, 1 }, { 0, 16, 0, u0, v0, 1 },
+    { x0, 0, 0, u0, v1, 1 }, { x1, 0, 0, u1, v1, 1 },
+    { x1, fh, 0, u1, v0, 1 }, { x0, fh, 0, u0, v0, 1 },
   }
   local indices = {}
   Voxel3D.pushQuad(indices, 0)
@@ -62,7 +81,12 @@ end
 -- ground whether or not anything hides it; and the sun must see the same
 -- outline the camera does, or a shadow stops matching what casts it.
 function SpriteBillboards.mesh(def, frame)
-  local key = def.image .. "#" .. frame
+  -- Size is part of the key too: two defs can point at the same sheet
+  -- with different frameWidth/frameHeight (a mod's derived variant of a
+  -- shared asset), and previously that could only alias because every
+  -- card was implicitly 16x16.
+  local key = def.image .. "#" .. frame .. "#"
+              .. (def.frameWidth or 16) .. "x" .. (def.frameHeight or 16)
   if meshes[key] == nil then
     local ok, m = pcall(buildCard, def, frame)
     meshes[key] = (ok and m) or false


### PR DESCRIPTION
buildCard now sizes the quad from def.frameWidth/frameHeight (falling back to 16) instead of hardcoding 16, and bakes a compensating x0 = 8 - frameWidth/2 offset so the card still lands centered on the tile through the shared -8 recenter shift in billboardMatrix/Voxel3D.casterMatrix downstream — no changes needed to either of those. I also fixed a latent mesh-cache key collision (two defs sharing one sheet at different sizes would previously alias, since size wasn't part of the key).