### PR TITLE
fix: preserve staged battle layouts

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -16,6 +16,10 @@ tests/goldens/shadow_golden.txt
 # Repo-only: issue templates must never ship in the mod zip.
 .github
 tests/shadow_runtime_test.lua
+tests/battle_layout_test.lua
+tests/battle_wide_hud_test.lua
+tests/battle_pics_detached_pixel_test.lua
+tests/battle_shadow_alignment_test.lua
 tools/thread_smoke/main.lua
 
 # Local analysis, backup, and historical package artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.8.4] - 2026-08-23
+
+### Fixed: staged battle layout and UI
+
+- BATTLE LAYOUT is no longer forced to OG or removed while staged battles are enabled; OG and WIDE are preserved through battle entry and map changes.
+- Unified battle layout metrics now keep rendering, captured battle textures, camera framing, HUD anchors, and coordinate conversion aligned for OG/WIDE, FIXED/FILL, DPI scaling, and offset screen positions.
+- Removed the translucent WIDE-mode HUD panels that could remain over the battle scene.
+- Removed isolated one-pixel islands from decoded battle art so a corrupt sprite texel cannot render as a detached black dash in the arena.
+
 ## [1.8.2] - 2026-08-19
 
 ### Fixed: voxel mode flickering between 2D and 3D (BUG-3)

--- a/lib/BattlePics.lua
+++ b/lib/BattlePics.lua
@@ -113,6 +113,57 @@ BattlePics.FILL = { 1, 1, 1, 1 }
 -- Anything at or under this alpha counts as keyed-out rather than drawn.
 local CUT = 0.5
 
+-- A decoded battle pic is a single drawing. A lone opaque texel separated
+-- from that drawing is not a sprite feature: when its 160x144 capture is
+-- stood up in the voxel scene, it becomes a conspicuous floating dash.
+BattlePics.DETACHED_INK_MAX = 1
+
+-- Remove tiny disconnected opaque islands from a decoded pic. This is done
+-- before measuring the artwork's bounds, so a corrupt pixel cannot enlarge
+-- the fill region or survive as its own world-space billboard fragment.
+function BattlePics.removeDetachedPixels(data, w, h)
+  local seen, removed = {}, 0
+  local function keyFor(x, y) return y * w + x end
+  local function opaque(x, y)
+    local _, _, _, a = data:getPixel(x, y)
+    return a > CUT
+  end
+  local function visit(stack, x, y)
+    if x < 0 or y < 0 or x >= w or y >= h then return end
+    local key = keyFor(x, y)
+    if seen[key] or not opaque(x, y) then return end
+    seen[key] = true
+    stack[#stack + 1] = key
+  end
+
+  for y = 0, h - 1 do
+    for x = 0, w - 1 do
+      local first = keyFor(x, y)
+      if not seen[first] and opaque(x, y) then
+        local stack, component = {}, {}
+        visit(stack, x, y)
+        while #stack > 0 do
+          local key = stack[#stack]
+          stack[#stack] = nil
+          component[#component + 1] = key
+          local px, py = key % w, math.floor(key / w)
+          visit(stack, px - 1, py)
+          visit(stack, px + 1, py)
+          visit(stack, px, py - 1)
+          visit(stack, px, py + 1)
+        end
+        if #component <= BattlePics.DETACHED_INK_MAX then
+          for _, key in ipairs(component) do
+            data:setPixel(key % w, math.floor(key / w), 0, 0, 0, 0)
+            removed = removed + 1
+          end
+        end
+      end
+    end
+  end
+  return removed
+end
+
 -- Read the pixels the engine would actually blit. A LOVE Image does not hand
 -- its data back, so it is drawn into a canvas of its own size and the canvas
 -- is read -- which is also what makes this work for every path that produces
@@ -306,6 +357,7 @@ function BattlePics.filled(img, sealBottom)
     local data = readBack(img)
     if not data then return end
     local w, h = data:getDimensions()
+    local removed = BattlePics.removeDetachedPixels(data, w, h)
     local x0, y0, x1, y1 = inkBounds(data, w, h)
     if not x0 then return end          -- a pic with nothing drawn in it
     local outside = markOutside(data, w, h, x0, y0, x1, y1, sealBottom)
@@ -314,7 +366,7 @@ function BattlePics.filled(img, sealBottom)
     local fr = pr or fill[1]
     local fg = pg or fill[2]
     local fb = pb or fill[3]
-    local changed = false
+    local changed = removed > 0
     -- only inside the box: everything beyond it is frame the artist never
     -- reached, and filling that would put the mon in a white rectangle
     for y = y0, y1 do

--- a/lib/BattleScene.lua
+++ b/lib/BattleScene.lua
@@ -53,10 +53,13 @@ local Map = require("src.world.Map")
 
 local BattleScene = {}
 
--- The GB frame the battle screen is drawn in, and the frame BattleCam's rig
--- is solved against.
+-- The classic frame the battle screen is drawn in.  BattleState may expose a
+-- wider native surface while a WIDE battle is active; all consumers go
+-- through layoutMetrics() below rather than assuming these dimensions.
 BattleScene.GB_W = 160
 BattleScene.GB_H = 144
+BattleScene.WIDE_W = 304
+BattleScene.WIDE_H = 144
 
 -- A map cell in world pixels: the overworld square a mon stands on, which is
 -- both what the arena is measured in and what a mon is sized to.
@@ -77,21 +80,6 @@ BattleScene.SHADOW_ALPHA = 0.68
 -- transparent would show the letterbox clear through the gaps.
 local INDOOR_SHADE = 4
 
--- ------- where the GB frame sits inside the window
---
--- Renderer blits worldOverride one canvas pixel to one screen pixel and then
--- blits the 160x144 UI canvas into a centred, integer-scaled letterbox. So
--- these have to agree with Renderer:endFrame exactly, or the pins land off
--- the mons by however much they disagree.
-function BattleScene.letterbox()
-  local Renderer = require("src.render.Renderer")
-  local pw, ph = BattleScene.pixelSize()
-  local s = Renderer:fitScale()
-  return math.floor((pw - BattleScene.GB_W * s) / 2),
-         math.floor((ph - BattleScene.GB_H * s) / 2),
-         s, pw, ph
-end
-
 -- The window in FRAMEBUFFER pixels, which is what the override blit works
 -- in. love.graphics.getDimensions is in LOVE units and differs from this by
 -- the display density on mobile.
@@ -101,6 +89,305 @@ function BattleScene.pixelSize()
     if pw and ph and pw > 0 and ph > 0 then return pw, ph end
   end
   return love.graphics.getDimensions()
+end
+
+local function number(value, fallback)
+  return type(value) == "number" and value or fallback
+end
+
+local function pair(value)
+  if type(value) ~= "table" then return nil end
+  local x = value.x
+  if x == nil then x = value[1] end
+  local y = value.y
+  if y == nil then y = value[2] end
+  if type(x) ~= "number" or type(y) ~= "number" then return nil end
+  return x, y
+end
+
+local function methodValue(owner, name, ...)
+  if not (owner and type(owner[name]) == "function") then return nil end
+  local ok, value, second = pcall(owner[name], owner, ...)
+  if not ok then return nil end
+  return value, second
+end
+
+local function methodTable(owner, name, ...)
+  if not (owner and type(owner[name]) == "function") then return nil end
+  local ok, value = pcall(owner[name], owner, ...)
+  return ok and value or nil
+end
+
+local function battleOptions(battle)
+  local game = battle and battle.game
+  return game and game.save and game.save.options or nil
+end
+
+-- Screen-position support is deliberately kept at this boundary.  Newer
+-- engine builds expose it on BattleState, while older compatible builds only
+-- carry the value in save options.  The battle renderer should not need to
+-- know which generation supplied the position.
+local function positionFor(battle, frame, surfaceW, surfaceH, scale, pw, ph)
+  local raw = frame and frame.position
+  local directX = frame and frame.viewportX
+  local directY = frame and frame.viewportY
+
+  if raw == nil then
+    local owners = {}
+    if battle then
+      owners[#owners + 1] = battle
+      if battle.game then
+        owners[#owners + 1] = battle.game
+        if battle.game.renderer then
+          owners[#owners + 1] = battle.game.renderer
+        end
+      end
+    end
+    for _, owner in ipairs(owners) do
+      for _, name in ipairs({ "screenPosition", "layoutPosition", "uiPosition" }) do
+        local value, second = methodValue(owner, name)
+        local x, y = pair(value)
+        if x ~= nil then raw = { x = x, y = y }; break end
+        if type(value) == "number" and type(second) == "number" then
+          raw = { x = value, y = second }; break
+        end
+        if type(value) == "string" then raw = value; break end
+      end
+      if raw ~= nil then break end
+    end
+  end
+
+  local options = battleOptions(battle)
+  if raw == nil and options then
+    for _, name in ipairs({ "battleScreenPosition", "battleScreenPos",
+                            "battlePosition", "screenPosition", "screenPos" }) do
+      if options[name] ~= nil then raw = options[name]; break end
+    end
+    if raw == nil then
+      local x = options.battleScreenX or options.battlePosX
+                or options.battleOffsetX
+      local y = options.battleScreenY or options.battlePosY
+                or options.battleOffsetY
+      if type(x) == "number" and type(y) == "number" then
+        raw = { x = x, y = y }
+      end
+    end
+  end
+
+  local offsetX, offsetY = pair(raw)
+  if offsetX == nil and type(raw) == "string" then
+    local name = raw:lower():gsub("_", "-")
+    local horizontal = name:find("left", 1, true) and -1
+                       or name:find("right", 1, true) and 1 or 0
+    local vertical = name:find("top", 1, true) and -1
+                     or name:find("bottom", 1, true) and 1 or 0
+    local spareX = math.max(0, pw - surfaceW * scale) / scale
+    local spareY = math.max(0, ph - surfaceH * scale) / scale
+    offsetX, offsetY = horizontal * spareX / 2, vertical * spareY / 2
+  end
+  offsetX, offsetY = offsetX or 0, offsetY or 0
+
+  local centeredX = math.floor((pw - surfaceW * scale) / 2)
+  local centeredY = math.floor((ph - surfaceH * scale) / 2)
+  local viewportX = directX or centeredX + math.floor(offsetX * scale + 0.5)
+  local viewportY = directY or centeredY + math.floor(offsetY * scale + 0.5)
+  if directX ~= nil then offsetX = (viewportX - centeredX) / scale end
+  if directY ~= nil then offsetY = (viewportY - centeredY) / scale end
+  return viewportX, viewportY, offsetX, offsetY
+end
+
+local function anchorsFor(battle, surfaceW, surfaceH)
+  local custom = methodTable(battle, "layoutAnchors", surfaceW, surfaceH)
+  if type(custom) == "table" and custom.player and custom.enemy then
+    return custom
+  end
+
+  -- WideBattle keeps the original 160px pic regions but translates the player
+  -- region by (20, 8) and the enemy region by (136, 0).  Keep those offsets in
+  -- the same layout boundary as the surface dimensions so the world cards,
+  -- effects and HUD all use one composition.
+  local playerX, playerY = 26, 96
+  local enemyX, enemyY = 124, 56
+  if surfaceW > BattleScene.GB_W then
+    playerX, playerY = playerX + 20, playerY + 8
+    enemyX, enemyY = enemyX + 136, enemyY
+  end
+  return {
+    player = { playerX, playerY },
+    enemy = { enemyX, enemyY },
+  }
+end
+
+local function hudFor(surfaceW)
+  if surfaceW > BattleScene.GB_W then
+    return {
+      enemy = { 0, 0, 128, 32 },
+      player = { 184, 56, 120, 40 },
+    }
+  end
+  return {
+    enemy = { 8, 0, 80, 32 },
+    player = { 72, 56, 88, 40 },
+  }
+end
+
+local function shiftedCamera(camera, metrics, vw, vh)
+  if not (camera and camera.eye and camera.focus) then return camera end
+  local centerX = metrics.viewportX + metrics.viewportW / 2
+  local centerY = metrics.viewportY + metrics.viewportH / 2
+  local deltaX = centerX - metrics.pw / 2
+  local deltaY = centerY - metrics.ph / 2
+  if math.abs(deltaX) < 0.01 and math.abs(deltaY) < 0.01 then
+    return camera
+  end
+
+  local eye, focus = camera.eye, camera.focus
+  local fx, fy, fz = focus[1] - eye[1], focus[2] - eye[2], focus[3] - eye[3]
+  local fl = math.sqrt(fx * fx + fy * fy + fz * fz)
+  if fl < 1e-6 then return camera end
+  fx, fy, fz = fx / fl, fy / fl, fz / fl
+  local up = camera.up or { 0, 1, 0 }
+  local rx = fy * up[3] - fz * up[2]
+  local ry = fz * up[1] - fx * up[3]
+  local rz = fx * up[2] - fy * up[1]
+  local rl = math.sqrt(rx * rx + ry * ry + rz * rz)
+  if rl < 1e-6 then return camera end
+  rx, ry, rz = rx / rl, ry / rl, rz / rl
+  local ux = ry * fz - rz * fy
+  local uy = rz * fx - rx * fz
+  local uz = rx * fy - ry * fx
+
+  -- `vw`/`vh` are the world span of the full render canvas at the focus
+  -- plane. Move the camera, rather than merely changing the post-projection
+  -- conversion, so the rendered world and the battle UI share the same
+  -- off-centre viewport.
+  local worldX = deltaX * vw / metrics.pw
+  local worldY = deltaY * vh / metrics.ph
+  local sx = -rx * worldX + ux * worldY
+  local sy = -ry * worldX + uy * worldY
+  local sz = -rz * worldX + uz * worldY
+
+  local out = {}
+  for key, value in pairs(camera) do out[key] = value end
+  out.eye = { eye[1] + sx, eye[2] + sy, eye[3] + sz }
+  out.focus = { focus[1] + sx, focus[2] + sy, focus[3] + sz }
+  if camera.up then out.up = { camera.up[1], camera.up[2], camera.up[3] } end
+  return out
+end
+
+-- The one layout boundary for staged battles.  Coordinates returned here are
+-- physical framebuffer pixels for the viewport, with logical battle pixels
+-- retained for the camera pins and HUD anchors.
+function BattleScene.layoutMetrics(battle, frame)
+  frame = frame or {}
+  local surfaceW, surfaceH = BattleScene.GB_W, BattleScene.GB_H
+  if battle and type(battle.uiSize) == "function" then
+    local ok, w, h = pcall(battle.uiSize, battle)
+    if ok and type(w) == "number" and type(h) == "number"
+       and w >= BattleScene.GB_W and h >= BattleScene.GB_H then
+      surfaceW, surfaceH = math.floor(w), math.floor(h)
+    end
+  elseif battle and type(battle.wideLayout) == "function" then
+    local ok, wide = pcall(battle.wideLayout, battle)
+    if ok and wide then surfaceW, surfaceH = BattleScene.WIDE_W, BattleScene.WIDE_H end
+  end
+
+  local pw = number(frame.pw, nil)
+  local ph = number(frame.ph, nil)
+  local dpiX = number(frame.dpiX, nil)
+  local dpiY = number(frame.dpiY, nil)
+  if not (pw and ph) then pw, ph = BattleScene.pixelSize() end
+  if not dpiX or not dpiY then
+    local ww, wh = love.graphics.getDimensions()
+    dpiX = dpiX or ((ww and ww > 0) and pw / ww or 1)
+    dpiY = dpiY or ((wh and wh > 0) and ph / wh or 1)
+  end
+  dpiX, dpiY = math.max(1e-6, dpiX), math.max(1e-6, dpiY)
+
+  local fill = frame.fill
+  if fill == nil and battle and type(battle.wantsFillScale) == "function" then
+    local ok, value = pcall(battle.wantsFillScale, battle)
+    fill = ok and value == true or false
+  end
+  fill = fill == true
+
+  local fitScale = math.min(pw / surfaceW, ph / surfaceH)
+  local fixedScale = math.max(1, math.floor(fitScale))
+  local fillScale = fitScale
+  local scale = number(frame.scale, nil)
+  if not scale and not frame.pw and not frame.ph then
+    local Renderer = require("src.render.Renderer")
+    local ok, currentW, currentH = pcall(Renderer.uiSize, Renderer)
+    if ok and currentW == surfaceW and currentH == surfaceH
+       and type(Renderer.fitScale) == "function" and not fill then
+      local okScale, fit = pcall(Renderer.fitScale, Renderer)
+      if okScale and type(fit) == "number" and fit > 0 then
+        scale, fixedScale = fit, fit
+      end
+    end
+  end
+  if not scale then
+    scale = fill and fillScale or fixedScale
+  end
+
+  local viewportX, viewportY, offsetX, offsetY =
+    positionFor(battle, frame, surfaceW, surfaceH, scale, pw, ph)
+  local anchors = anchorsFor(battle, surfaceW, surfaceH)
+  local dx = anchors.enemy[1] - anchors.player[1]
+  local dy = anchors.enemy[2] - anchors.player[2]
+
+  return {
+    surfaceW = surfaceW, surfaceH = surfaceH,
+    viewportX = viewportX, viewportY = viewportY,
+    viewportW = surfaceW * scale, viewportH = surfaceH * scale,
+    offsetX = offsetX, offsetY = offsetY,
+    scale = scale, fill = fill,
+    scaleMode = fill and "fill" or "fixed",
+    fitScale = fitScale, fixedScale = fixedScale, fillScale = fillScale,
+    dpiX = dpiX, dpiY = dpiY,
+    drawScaleX = scale / dpiX, drawScaleY = scale / dpiY,
+    pw = pw, ph = ph,
+    -- Side-pic captures remain a classic 160x144 logical frame even when
+    -- the composed battle surface is WIDE.  Animation captures use the full
+    -- surface; keeping both dimensions here prevents either caller from
+    -- baking that distinction into another layout assumption.
+    captureW = BattleScene.GB_W, captureH = BattleScene.GB_H,
+    anchors = anchors,
+    hud = hudFor(surfaceW),
+    anchorSpan = math.sqrt(dx * dx + dy * dy),
+  }
+end
+
+function BattleScene.animationOffset(battle, metrics)
+  if not (battle and metrics and metrics.surfaceW > BattleScene.GB_W) then
+    return 0, 0
+  end
+  local player = battle.animPlayer
+  local sprites
+  if battle.animPlaying and player then
+    local step = player.steps and player.steps[player.stepIndex]
+    sprites = step and step.sprites
+  elseif battle.lockedBall and player then
+    sprites = battle.lockedBall
+  end
+  if not sprites then return 0, 0 end
+  local ok, WideBattle = pcall(require, "src.battle.WideBattle")
+  if not (ok and WideBattle and type(WideBattle.animationOffset) == "function") then
+    return 0, 0
+  end
+  local okOffset, x, y = pcall(WideBattle.animationOffset, sprites)
+  if okOffset and type(x) == "number" and type(y) == "number" then
+    return x, y
+  end
+  return 0, 0
+end
+
+-- Renderer blits worldOverride one canvas pixel to one screen pixel and then
+-- blits the battle surface into the viewport described above.  Keep this
+-- compatibility helper for callers that only need the classic tuple.
+function BattleScene.letterbox(battle, frame)
+  local m = BattleScene.layoutMetrics(battle, frame)
+  return m.viewportX, m.viewportY, m.scale, m.pw, m.ph, m
 end
 
 function BattleScene.renderScale(level)
@@ -114,8 +401,8 @@ end
 -- tan(fov/2) * pw/ph, and the letterbox is 160*s of those pw pixels, which
 -- works back out to the GB frame's own 160/144. So one scale on the vertical
 -- pins both axes.
-function BattleScene.letterboxFov(fovGB, ph, s)
-  local span = BattleScene.GB_H * s
+function BattleScene.letterboxFov(fovGB, ph, s, surfaceH)
+  local span = (surfaceH or BattleScene.GB_H) * s
   if span <= 0 then return fovGB end
   return 2 * math.atan(math.tan(fovGB / 2) * ph / span)
 end
@@ -190,10 +477,12 @@ end
 -- turn it around to face the camera it is standing in front of.
 local function monMatrix(tex, x, groundY, z, mirror)
   local k = BattleBillboard.FULL_W / BattleBillboard.FULL_PIC
-  local w = BattleScene.GB_W * k
-  local h = BattleScene.GB_H * k
-  local ox = -((tex.ax / BattleScene.GB_W) - 0.5) * w
-  local oy = -((BattleScene.GB_H - tex.ay) / BattleScene.GB_H) * h
+  local captureW = tex.captureW or BattleScene.GB_W
+  local captureH = tex.captureH or BattleScene.GB_H
+  local w = captureW * k
+  local h = captureH * k
+  local ox = -((tex.ax / captureW) - 0.5) * w
+  local oy = -((captureH - tex.ay) / captureH) * h
   local yaw = BattleBillboard.yawToward(x, z, Voxel3D.eye)
   local card = Mat4.mul(Mat4.translate(ox, oy, 0), Mat4.scale(w, h, 1))
   if mirror then card = Mat4.mul(Mat4.scale(-1, 1, 1), card) end
@@ -242,11 +531,12 @@ BattleScene.monCards = monCards
 -- Reads Voxel3D.eye at CALL time, like the cards -- call it per eye.
 -- Returns the model matrix for BattleBillboard's unit card (x -0.5..0.5,
 -- y 0..1 up, v flipped), or nil where the anchors are degenerate.
-function BattleScene.fxCard(arena, groundY, anchors)
+function BattleScene.fxCard(arena, groundY, anchors, metrics)
   local p, e = anchors.player, anchors.enemy
   local dgb = e[1] - p[1]
   if math.abs(dgb) < 1 then return nil end
-  local GW, GH = BattleScene.GB_W, BattleScene.GB_H
+  local GW = metrics and metrics.surfaceW or BattleScene.GB_W
+  local GH = metrics and metrics.surfaceH or BattleScene.GB_H
   local Px, Py, Pz = arena.player[1], groundY, arena.player[2]
   local Ex, Ey, Ez = arena.enemy[1], groundY, arena.enemy[2]
   local s = BattleBillboard.FULL_W / BattleBillboard.FULL_PIC
@@ -401,20 +691,26 @@ function BattleScene.groundY(map, arena)
   return (ok and h) or 0
 end
 
--- Where a world point lands in GB frame coordinates under `vp`, or nil when
--- it is behind the camera. This is the function the pins are built on: it
--- takes the window-resolution clip position and divides the letterbox back
--- out of it, so the answer is in the same 160x144 space the battle screen
--- draws its pics in.
-function BattleScene.toGB(vp, wx, wy, wz, lx, ly, s, pw, ph)
+-- Where a world point lands in the active battle surface under `vp`, or nil
+-- when it is behind the camera. The metrics argument keeps the conversion
+-- aligned with OG/WIDE, FIXED/FILL, DPI and screen-position choices.
+function BattleScene.toGB(vp, wx, wy, wz, metricsOrX, ly, s, pw, ph)
   local cx = vp[1] * wx + vp[2] * wy + vp[3] * wz + vp[4]
   local cy = vp[5] * wx + vp[6] * wy + vp[7] * wz + vp[8]
   local cw = vp[13] * wx + vp[14] * wy + vp[15] * wz + vp[16]
   if cw <= 1e-6 then return nil end
+  local metrics
+  if type(metricsOrX) == "table" then
+    metrics = metricsOrX
+  else
+    metrics = { viewportX = metricsOrX, viewportY = ly, scale = s,
+                pw = pw, ph = ph }
+  end
   -- viewProjection already flipped clip Y into LOVE's Y-down convention
-  local px = (cx / cw * 0.5 + 0.5) * pw
-  local py = (cy / cw * 0.5 + 0.5) * ph
-  return (px - lx) / s, (py - ly) / s
+  local px = (cx / cw * 0.5 + 0.5) * metrics.pw
+  local py = (cy / cw * 0.5 + 0.5) * metrics.ph
+  return (px - metrics.viewportX) / metrics.scale,
+         (py - metrics.viewportY) / metrics.scale
 end
 
 -- Render the arena and hand back { canvas, player = {x,y}, enemy = {x,y} },
@@ -459,10 +755,14 @@ local function tickTiles()
   pcall(require("src.render.TileRenderer").tick)
 end
 
-function BattleScene.render(state, arena, textures, token)
+function BattleScene.render(state, arena, textures, token, battle)
   if not (state and state.map and arena) then return nil end
   if not Voxel3D.available() then return nil end
   tickTiles()
+
+  -- The battle state owns the active composition. Passing it explicitly keeps
+  -- the 3D pass in step with the UI when the stack is wide, filled or offset.
+  local metrics = BattleScene.layoutMetrics(battle)
 
   -- the floor the fight is staged on: normally the player's own, sometimes
   -- another floor of the same cave or building (see BattleArena)
@@ -510,7 +810,8 @@ function BattleScene.render(state, arena, textures, token)
     if not terrain then return nil end
   end
 
-  local lx, ly, s, pw, ph = BattleScene.letterbox()
+  local lx, ly, s, pw, ph = metrics.viewportX, metrics.viewportY,
+                             metrics.scale, metrics.pw, metrics.ph
   if not (pw > 0 and ph > 0 and s > 0) then return nil end
 
   local palette = paletteFor(state, host)
@@ -520,7 +821,7 @@ function BattleScene.render(state, arena, textures, token)
 
   local groundY = BattleScene.groundY(host, arena)
   local cam, pitch = BattleCam.rig(arena, groundY)
-  cam.fov = BattleScene.letterboxFov(cam.fov, ph, s)
+  cam.fov = BattleScene.letterboxFov(cam.fov, ph, s, metrics.surfaceH)
 
   local cx, cy = arena.mid[1], arena.mid[2]
   -- the world extents the sun frustum is fitted to; the camera itself is
@@ -528,8 +829,9 @@ function BattleScene.render(state, arena, textures, token)
   -- the player's zoom is part of this: the sun's box is fitted to what the
   -- frame holds, so a shot pulled wide has to light the ground it just
   -- brought into view rather than the ground the rig alone would have
-  local vh = BattleCam.frameH(arena) * ph / (BattleScene.GB_H * s)
+  local vh = BattleCam.frameH(arena) * ph / (metrics.surfaceH * s)
   local vw = vh * pw / ph
+  cam = shiftedCamera(cam, metrics, vw, vh)
 
   -- the cards need the camera's eye to face it, so the rig has to be live
   -- before they are built; Voxel3D.eye is set by viewProjection, which
@@ -698,22 +1000,22 @@ function BattleScene.render(state, arena, textures, token)
 
     local vp = Voxel3D.vp
     local pmx, pmy = BattleScene.toGB(vp, arena.player[1], groundY,
-                                      arena.player[2], lx, ly, s, pw, ph)
+                                      arena.player[2], metrics)
     local emx, emy = BattleScene.toGB(vp, arena.enemy[1], groundY,
-                                      arena.enemy[2], lx, ly, s, pw, ph)
+                                      arena.enemy[2], metrics)
     if not (pmx and emx) then return end
     -- How wide one overworld square is on screen where each mon stands, in
     -- GB pixels. This is what the pics are scaled to: a mon covers its own
     -- square and no more, at whatever the drift has done to the distance.
     local half = BattleScene.CELL / 2
     local pl = BattleScene.toGB(vp, arena.player[1] - half, groundY,
-                                arena.player[2], lx, ly, s, pw, ph)
+                                arena.player[2], metrics)
     local pr = BattleScene.toGB(vp, arena.player[1] + half, groundY,
-                                arena.player[2], lx, ly, s, pw, ph)
+                                arena.player[2], metrics)
     local el = BattleScene.toGB(vp, arena.enemy[1] - half, groundY,
-                                arena.enemy[2], lx, ly, s, pw, ph)
+                                arena.enemy[2], metrics)
     local er = BattleScene.toGB(vp, arena.enemy[1] + half, groundY,
-                                arena.enemy[2], lx, ly, s, pw, ph)
+                                arena.enemy[2], metrics)
     if not (pl and pr and el and er) then return end
     out = {
       canvas = canvas,
@@ -724,6 +1026,12 @@ function BattleScene.render(state, arena, textures, token)
       -- the letterbox, so the depth-of-field pass can put its sharp band on
       -- the two marks rather than on a fraction of the window
       lx = lx, ly = ly, scale = s, pw = pw, ph = ph,
+      viewportX = metrics.viewportX, viewportY = metrics.viewportY,
+      surfaceW = metrics.surfaceW, surfaceH = metrics.surfaceH,
+      offsetX = metrics.offsetX, offsetY = metrics.offsetY,
+      dpiX = metrics.dpiX, dpiY = metrics.dpiY,
+      anchors = metrics.anchors, anchorSpan = metrics.anchorSpan,
+      layout = metrics,
       -- and the hour's light, for anything drawn over this shot that is NOT
       -- geometry and so never went past the shader that applied it -- the back
       -- pic pinned to the menu (see OverworldBattle.backPinned). Neutral

--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -298,7 +298,9 @@ function OverworldBattle.animScale(shot, px, py)
   local dx, dy = shot.enemy[1] - px, shot.enemy[2] - py
   local span = math.sqrt(dx * dx + dy * dy)
   if not (span > 1) then return 1 end
-  local k = span / OverworldBattle.ANCHOR_SPAN
+  local base = shot.anchorSpan or OverworldBattle.ANCHOR_SPAN
+  if not (base > 0) then return 1 end
+  local k = span / base
   return math.max(OverworldBattle.ANIM_SCALE_MIN,
                   math.min(OverworldBattle.ANIM_SCALE_MAX, k))
 end
@@ -339,13 +341,11 @@ end
 
 -- ------- one right battle layout
 --
--- Everything this file composes is measured in the GB's own 160x144 frame: the
--- two ANCHORs the arena camera is solved to put a cell under, the HUD_RECTs
--- the frosted panels are cut to, and the full-frame white intercepted to let
--- the world through. BATTLE LAYOUT's WIDE lays the same battle out on a
--- 304x144 surface (src/battle/WideBattle.lua), which moves every one of those
--- -- the mons would stand where no camera was solved for them, and the panels
--- would land beside the HUDs they are supposed to be under.
+-- The classic anchors and HUD rectangles remain the OG defaults. The active
+-- BattleScene layout metrics replace them for WIDE, including the translated
+-- surface positions from src/battle/WideBattle.lua. The background-fill shim,
+-- camera shot and animation layer consume that same boundary, so the world
+-- and engine UI never solve against different surfaces.
 --
 -- So while a fight can be staged on the map there is one right answer, and it
 -- is SET rather than worked around. The engine reads the option live
@@ -353,20 +353,6 @@ end
 -- top state for its surface the same way), so writing it here lands on the
 -- battle being pushed as well as every one after it.
 --
--- This is the last line rather than the first: the OPTIONS menu takes the row
--- off the list and pins the value while 3D-BTL is on (see main.lua), so a
--- player is never offered a switch that gets reverted under them. What reaches
--- here is a value that arrived some other way -- a save written before the mod
--- was installed, the mod manager's own page, another mod.
-function OverworldBattle.forceOG(g)
-  g = g or game()
-  local opts = g and g.save and g.save.options
-  if not opts or opts.battleLayout ~= "wide" then return false end
-  opts.battleLayout = "og"
-  if g.writeOptions then pcall(g.writeOptions, g) end
-  return true
-end
-
 -- Where THIS fight stands, on whichever rung is running: the map's own
 -- ground, or the pair of discs a B rung carries with it.
 --
@@ -403,10 +389,6 @@ function OverworldBattle.begin(state, battle)
 
   local arena = OverworldBattle.stageFor(state)
   if not arena then return false end
-
-  -- the fight is staged from here on, so the layout it is composed for is not
-  -- optional any more (see forceOG)
-  OverworldBattle.forceOG()
 
   session = { state = state, arena = arena, battle = battle, shot = nil,
               armed = false, token = 0 }
@@ -517,7 +499,7 @@ function OverworldBattle.update(dt)
   end
   session.token = (session.token or 0) + 1
   local ok, shot = pcall(BattleScene.render, session.state, session.arena,
-                         textures, session.token)
+                         textures, session.token, session.battle)
   if not ok then
     -- One failure retires the arena for THIS battle and nothing else: the
     -- battle screen carries on as the engine's own, the free-roam pipeline
@@ -587,6 +569,7 @@ end
 -- made through sideTexture: let the engine draw what it always draws,
 -- catch it on a canvas, stand the canvas in the scene.
 local animLayer = nil
+local animLayerW, animLayerH = nil, nil
 -- the engine's own drawAnimLayer, captured by install(). Declared HERE,
 -- above the function that reads it: a local declared further down the
 -- chunk would leave this function reading a global of the same name --
@@ -597,12 +580,15 @@ local innerAnim = nil
 function OverworldBattle.animTexture(battle)
   if not (innerAnim and battle) then return nil end
   if not (love.graphics and love.graphics.newCanvas) then return nil end
-  if not animLayer then
+  local layout = BattleScene.layoutMetrics(battle)
+  if not animLayer or animLayerW ~= layout.surfaceW
+     or animLayerH ~= layout.surfaceH then
     local ok, c = pcall(love.graphics.newCanvas,
-                        BattleScene.GB_W, BattleScene.GB_H)
+                        layout.surfaceW, layout.surfaceH, { dpiscale = 1 })
     if not (ok and c) then return nil end
     pcall(c.setFilter, c, "nearest", "nearest")
     animLayer = c
+    animLayerW, animLayerH = layout.surfaceW, layout.surfaceH
   end
   local g = love.graphics
   local prevCanvas = g.getCanvas()
@@ -613,6 +599,8 @@ function OverworldBattle.animTexture(battle)
     g.clear(0, 0, 0, 0)
     g.setBlendMode("alpha")
     g.setColor(1, 1, 1, 1)
+    local dx, dy = BattleScene.animationOffset(battle, layout)
+    g.translate(dx, dy)
     innerAnim(battle, false)
     g.pop()
   end)
@@ -633,8 +621,11 @@ function OverworldBattle.worldAnim()
   local host = (session.state and session.state.map) or nil
   if not host then return nil end
   local groundY = BattleScene.groundY(host, session.arena)
+  local shot = session.shot
+  local layout = shot and shot.layout or BattleScene.layoutMetrics(session.battle)
+  local anchors = shot and shot.anchors or layout.anchors
   local model = BattleScene.fxCard(session.arena, groundY,
-                                   OverworldBattle.ANCHOR)
+                                   anchors, layout)
   if not model then return nil end
   return tex, model
 end
@@ -678,9 +669,10 @@ end
 local function withoutBackgroundFill(battle, fn)
   local g = love.graphics
   local rectangle = g.rectangle
+  local layout = BattleScene.layoutMetrics(battle)
   g.rectangle = function(mode, x, y, w, h, ...)
     if mode == "fill" and x == 0 and y == 0
-       and w == BattleScene.GB_W and h == BattleScene.GB_H then
+       and w == layout.surfaceW and h == layout.surfaceH then
       local r, gr, b, a = g.getColor()
       if r > 0.99 and gr > 0.99 and b > 0.99 then
         -- Two different full-frame whites, both replaced rather than drawn.
@@ -783,11 +775,11 @@ local innerPics = nil                   -- captured by install()
 -- (innerAnim, their sibling, is declared up beside animTexture, which
 -- sits earlier in the chunk than this group and must see the local)
 
-local function texCanvasFor(side)
+local function texCanvasFor(side, metrics)
   local c = texCanvas[side]
   if c then return c end
-  local ok, made = pcall(love.graphics.newCanvas, BattleScene.GB_W,
-                         BattleScene.GB_H, { dpiscale = 1 })
+  local ok, made = pcall(love.graphics.newCanvas, metrics.captureW,
+                         metrics.captureH, { dpiscale = 1 })
   if not ok then return nil end
   made:setFilter("nearest", "nearest")
   texCanvas[side] = made
@@ -821,7 +813,8 @@ local OFF = {
 function OverworldBattle.sideTexture(battle, side)
   if not (innerPics and battle) then return nil end
   if not sideVisible(battle, side) then return nil end
-  local canvas = texCanvasFor(side)
+  local metrics = BattleScene.layoutMetrics(battle)
+  local canvas = texCanvasFor(side, metrics)
   if not canvas then return nil end
 
   local g = love.graphics
@@ -866,7 +859,8 @@ function OverworldBattle.sideTexture(battle, side)
   elseif side == "player" and battle.showPlayerBack and battle.playerBackPic then
     trainer = true
   end
-  return { canvas = canvas, ax = ax, ay = ay, trainer = trainer }
+  return { canvas = canvas, ax = ax, ay = ay, trainer = trainer,
+           captureW = metrics.captureW, captureH = metrics.captureH }
 end
 
 -- Whether the hit flash is showing this frame.
@@ -1075,7 +1069,7 @@ function OverworldBattle.install()
     -- the air beside the one it was aimed at. Scaling about the same
     -- midpoint keeps every authored offset the same fraction of the gap it
     -- was authored as.
-    local a = OverworldBattle.ANCHOR
+    local a = shot.anchors or OverworldBattle.ANCHOR
     -- BACK SPRITES leaves the player's mon exactly where the GB put it, so that side
     -- contributes no movement at all and the pair's centre has gone half as
     -- far as the foe's mark did.
@@ -1174,22 +1168,12 @@ end
 -- Shadowed on the instance for this call only, the way drawZonePass shadows
 -- activeBgp: putting the field back to whatever it was (normally nil) lets the
 -- class method be found again.
--- Lay the plain HUD backings down under whichever blocks are about to
--- draw in the GB frame. The frosted-glass panels and the edge-snapped
--- composite are gone (see the removals ADR): the HUDs draw in their
--- classic slots, so each gets a simple semi-opaque backing -- the same
--- flat panels the old iOS path used -- and the text box keeps its own
--- white paper, exactly as the vanilla screen draws it.
+-- The engine owns the WIDE HUD panels and draws their bordered white boxes.
+-- Keep this seam as a no-op for callers from older staged-battle builds, but
+-- do not paint translucent backings over the world: those were the leftover
+-- frosted-glass rectangles visible between the real HUD and the battle field.
 function OverworldBattle.drawHudPanels(battle)
-  local shot = battle.dramaticShapeShot
-  if not shot then return end
-  local slide = (battle.introSlide or 0) * 4
-  local enemy, player = OverworldBattle.hudLive(battle, slide)
-  local rect = OverworldBattle.HUD_RECT
-  love.graphics.setColor(1, 1, 1, 0.84)
-  if enemy then love.graphics.rectangle("fill", rect.enemy[1], rect.enemy[2], rect.enemy[3], rect.enemy[4]) end
-  if player then love.graphics.rectangle("fill", rect.player[1], rect.player[2], rect.player[3], rect.player[4]) end
-  love.graphics.setColor(1, 1, 1, 1)
+  return
 end
 
 return OverworldBattle

--- a/lib/SettingsFeature.lua
+++ b/lib/SettingsFeature.lua
@@ -191,7 +191,6 @@ function SettingsFeature.new(ctx)
   function feature.installRowsHook(options)
     local Cache = options.Cache
     local deferToNextTick = options.deferToNextTick
-    local OverworldBattle = ctx.OverworldBattle
     local DebugOverlay = ctx.DebugOverlay
 
     local function dropRow(rows, id)
@@ -234,10 +233,6 @@ function SettingsFeature.new(ctx)
       dropRow(out, "tilt")
       dropRow(out, "gbcfx")
       dropRow(out, "battleBg")
-      if ctx.stagedBattles() then
-        OverworldBattle.forceOG(game)
-        dropRow(out, "battleLayout")
-      end
       for i = #out, 1, -1 do
         local id = type(out[i]) == "table" and out[i].id or ""
         id = id or ""

--- a/main.lua
+++ b/main.lua
@@ -311,13 +311,12 @@ mod.content.render_pipelines:register("voxel", {
     -- The manager's page can change any of these rows mid-session, and the
     -- current API has no options-changed event to announce it: the settings
     -- read LIVE through the options API on every read (ModSetting:read),
-    -- and the two pins the old event carried are re-asserted here on this
-    -- always-running tick instead. Both are guarded no-ops when already
-    -- correct (DayNight.forceSync, OverworldBattle.forceOG).
+    -- and the one pin the old event carried is re-asserted here on this
+    -- always-running tick instead. It is guarded as a no-op when already
+    -- correct (DayNight.forceSync).
     if Voxel.isFull(level) then
       DayNight.forceSync(require("src.core.Game"))
     end
-    if stagedBattles() then OverworldBattle.forceOG() end
     Voxel.update(dt, level)
     -- the first-person head, on the same tick: its blend in and out of the
     -- orbit, the mouse capture lifecycle, and the frame's stick-rate look.
@@ -564,11 +563,6 @@ applyFull = function(level)
   -- menu, which is the one part of the old screen FULL is least about. Set the
   -- same way, and changed back on the same row a keypress later.
   OverworldBattle.backSetting:setIndex(1, Game)
-  -- and the battle screen the staged fight is composed for. WIDE re-lays that
-  -- screen out on a 304x144 surface, which moves every anchor the arena camera
-  -- is solved against (OverworldBattle.forceOG); FULL has just switched staged
-  -- fights on, so the layout follows them.
-  OverworldBattle.forceOG(Game)
   -- and the sky on the clock on the wall: FULL pins DAYTIME to SYNC. Unlike
   -- the rest of the preset this one IS held, not just set -- the row is off
   -- the menu while FULL owns it (the rows hook below), so a value changed
@@ -580,14 +574,10 @@ end
 -- Whether a fight can be staged on the map, as far as the OPTIONS menu is
 -- concerned: the 3D-BTL row, and nothing else.
 --
--- It used to answer yes under FULL as well, on the grounds that FULL owned
--- that row and switched it on. FULL no longer owns it -- the row stays on the
--- menu under FULL and can be switched off there (see the rows hook) -- so that
--- clause would now claim staged battles for a preset the player had just
--- turned them off inside, pinning BATTLE LAYOUT to OG for a fight that is
--- never staged. The row is the only thing that decides, which is what every
--- other reader of this setting already believed: OverworldBattle.begin and
--- wantsFront both gate on enabled() alone.
+-- FULL does not own this row -- it stays on the menu under FULL and can be
+-- switched off there (see the rows hook). The row is the only thing that
+-- decides whether a staged battle is active, which is what every other reader
+-- already expects: OverworldBattle.begin and wantsFront both gate on enabled().
 --
 -- Deliberately NOT gated on Voxel3D.available(): the engine offers a
 -- pipeline's row whether or not the hardware can run it (Pipelines.rows), so
@@ -670,13 +660,10 @@ Cache.installLifecycle()
 
 -- The mod manager writes and persists these settings on its own, and the
 -- current API has no options-changed event to announce it -- so there is
--- nothing to subscribe to here. The settings read LIVE through the
--- options API on every read (ModSetting:read), which is what keeps each
--- row's rung in step with a value changed from the manager's page. The
--- two pins the old event also carried -- BATTLE LAYOUT under staged
--- battles, DAYTIME held at SYNC under FULL -- are re-asserted every tick
--- from the voxel pipeline's update hook instead (both are guarded no-ops
--- when already correct).
+-- nothing to subscribe to here. The settings read LIVE through the options
+-- API on every read (ModSetting:read), which keeps each row's rung in step
+-- with a value changed from the manager's page. DAYTIME's FULL preset pin is
+-- re-asserted every tick from the voxel pipeline's update hook.
 
 -- WorldFeature owns map edit/reload hooks and the Map:setBlock invalidation
 -- seam. Installing here preserves their order before settings-menu refresh.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "potato_voxel",
   "name": "PotatoVoxel",
-  "version": "1.8.2",
+  "version": "1.8.4",
   "log_url": "https://logs.potatovoxeldevreports.autos/52780bd4aed1f7ade206cfda0ad275174908b572addecfac/logs",
   "api": 2,
   "entry": "main.lua",

--- a/tests/battle_layout_test.lua
+++ b/tests/battle_layout_test.lua
@@ -1,0 +1,142 @@
+-- Pure regression coverage for the staged battle layout contract.
+local function check(condition, message)
+  if not condition then error(message, 2) end
+end
+
+local function eq(actual, expected, message)
+  if actual ~= expected then
+    error(('%s (expected %s, got %s)'):format(message, tostring(expected),
+                                             tostring(actual)), 2)
+  end
+end
+
+package.preload["src.render.PaletteFX"] = function() return {} end
+package.preload["src.world.Map"] = function() return {} end
+
+local empty = {}
+local V = {
+  require = function() return empty end,
+}
+
+local BattleScene = assert(loadfile("lib/BattleScene.lua"))(V)
+
+local function battle(wide, fill, position)
+  return {
+    uiSize = function()
+      return wide and 304 or 160, 144
+    end,
+    wantsFillScale = function()
+      return fill
+    end,
+    screenPosition = function()
+      return position
+    end,
+  }
+end
+
+local og = BattleScene.layoutMetrics(battle(false, false), {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+eq(og.surfaceW, 160, "OG layout keeps the classic width")
+eq(og.surfaceH, 144, "OG layout keeps the classic height")
+eq(og.scale, 5, "OG FIXED uses the largest integer scale")
+eq(og.viewportX, 240, "OG FIXED centers horizontally")
+eq(og.viewportY, 0, "OG FIXED centers vertically")
+
+local ogOffset = BattleScene.layoutMetrics(battle(false, false, { x = -16, y = 8 }), {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+eq(ogOffset.viewportX, 160, "OG offset moves the viewport horizontally")
+eq(ogOffset.viewportY, 40, "OG offset moves the viewport vertically")
+
+local wide = BattleScene.layoutMetrics(battle(true, false), {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+eq(wide.surfaceW, 304, "WIDE layout uses the widescreen surface")
+eq(wide.scale, 4, "WIDE FIXED uses the largest integer scale")
+eq(wide.viewportX, 32, "WIDE FIXED centers horizontally")
+eq(wide.viewportY, 72, "WIDE FIXED centers vertically")
+eq(wide.anchors.player[1], 46, "WIDE player anchor follows the wide field")
+eq(wide.anchors.player[2], 104, "WIDE player anchor follows the wide field")
+eq(wide.anchors.enemy[1], 260, "WIDE enemy anchor follows the wide field")
+eq(wide.anchors.enemy[2], 56, "WIDE enemy anchor follows the wide field")
+eq(wide.captureW, 160, "side captures retain their logical width")
+eq(wide.captureH, 144, "side captures retain their logical height")
+eq(wide.hud.enemy[1], 0, "WIDE enemy HUD follows the wide viewport")
+eq(wide.hud.player[1], 184, "WIDE player HUD follows the wide viewport")
+eq(wide.scaleMode, "fixed", "FIXED exposes its scale mode")
+
+local fill = BattleScene.layoutMetrics(battle(true, true), {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+check(fill.scale > 4 and fill.scale < 5,
+      "FILL uses a fractional scale when the window requires it")
+eq(fill.scaleMode, "fill", "FILL exposes its scale mode")
+eq(fill.fillScale, fill.scale, "FILL exposes its selected scale")
+eq(fill.viewportX, 0, "FILL has no horizontal bar when width is limiting")
+eq(fill.viewportY, 56, "FILL reports the centered vertical viewport origin")
+
+local offset = BattleScene.layoutMetrics(battle(true, false, { x = 8, y = -4 }), {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+eq(offset.viewportX, 64, "screen-position X offset moves the WIDE viewport")
+eq(offset.viewportY, 56, "screen-position Y offset moves the WIDE viewport")
+eq(offset.offsetX, 8, "layout metrics retain logical X offset")
+eq(offset.offsetY, -4, "layout metrics retain logical Y offset")
+local mapChanged = battle(true, false, { x = 8, y = -4 })
+local beforeMap = BattleScene.layoutMetrics(mapChanged, {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+mapChanged.map = { id = "ROUTE_2" }
+local afterMap = BattleScene.layoutMetrics(mapChanged, {
+  pw = 1280, ph = 720, dpiX = 1, dpiY = 1,
+})
+eq(afterMap.viewportX, beforeMap.viewportX,
+   "map changes do not reset the selected X layout")
+eq(afterMap.viewportY, beforeMap.viewportY,
+   "map changes do not reset the selected Y layout")
+
+local dpi = BattleScene.layoutMetrics(battle(false, false), {
+  pw = 1920, ph = 1080, dpiX = 2, dpiY = 1.5,
+})
+eq(dpi.dpiX, 2, "layout metrics retain horizontal DPI")
+eq(dpi.dpiY, 1.5, "layout metrics retain vertical DPI")
+eq(dpi.drawScaleX, dpi.scale / dpi.dpiX,
+   "logical X scale is derived from physical scale and DPI")
+eq(dpi.drawScaleY, dpi.scale / dpi.dpiY,
+   "logical Y scale is derived from physical scale and DPI")
+
+local identity = {
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+}
+local dx, dy = BattleScene.toGB(identity, 0, 0, 0, dpi)
+eq(dx, (0.5 * dpi.pw - dpi.viewportX) / dpi.scale,
+   "DPI-aware conversion uses physical X pixels")
+eq(dy, (0.5 * dpi.ph - dpi.viewportY) / dpi.scale,
+   "DPI-aware conversion uses physical Y pixels")
+local x, y = BattleScene.toGB(identity, 0, 0, 0, offset)
+eq(x, (0.5 * offset.pw - offset.viewportX) / offset.scale,
+   "coordinate conversion uses the selected viewport X")
+eq(y, (0.5 * offset.ph - offset.viewportY) / offset.scale,
+   "coordinate conversion uses the selected viewport Y")
+
+check(BattleScene.forceOG == nil, "BattleScene does not own a layout override")
+
+local function source(path)
+  local file = assert(io.open(path, "r"))
+  local text = file:read("*a")
+  file:close()
+  return text
+end
+
+check(not source("lib/SettingsFeature.lua"):find("battleLayout"),
+      "settings hook does not remove the engine Battle Layout row")
+check(not source("lib/OverworldBattle.lua"):find("forceOG"),
+      "staged battle entry has no forced-OG path")
+check(not source("main.lua"):find("forceOG"),
+      "pipeline updates and presets have no forced-OG path")
+
+print("battle_layout_test: ok")

--- a/tests/battle_pics_detached_pixel_test.lua
+++ b/tests/battle_pics_detached_pixel_test.lua
@@ -1,0 +1,31 @@
+local function check(condition, message)
+  if not condition then error(message, 2) end
+end
+
+local BattlePics = assert(loadfile("lib/BattlePics.lua"))({})
+
+local pixels = {
+  [0] = { [0] = { 0, 0, 0, 1 }, [1] = { 0, 0, 0, 1 } },
+  [1] = { [0] = { 0, 0, 0, 1 } },
+  [3] = { [5] = { 0, 0, 0, 1 } },
+}
+local data = {
+  getPixel = function(_, x, y)
+    local p = pixels[y] and pixels[y][x]
+    if p then return p[1], p[2], p[3], p[4] end
+    return 0, 0, 0, 0
+  end,
+  setPixel = function(_, x, y, r, g, b, a)
+    pixels[y] = pixels[y] or {}
+    pixels[y][x] = { r, g, b, a }
+  end,
+}
+
+check(BattlePics.removeDetachedPixels(data, 6, 4) == 1,
+      "one disconnected opaque sprite pixel is removed")
+check(select(4, data:getPixel(5, 3)) == 0,
+      "the removed detached pixel is transparent")
+check(select(4, data:getPixel(0, 0)) == 1,
+      "the sprite's connected body is retained")
+
+print("battle_pics_detached_pixel_test: ok")

--- a/tests/battle_shadow_alignment_test.lua
+++ b/tests/battle_shadow_alignment_test.lua
@@ -1,0 +1,19 @@
+-- Regression coverage for the ordinary staged-battle shadow controls.
+local function check(condition, message)
+  if not condition then error(message, 2) end
+end
+
+local file = assert(io.open("lib/BattleScene.lua", "r"))
+local source = file:read("*a")
+file:close()
+
+check(source:find("BrickProfile.battleActorShadowMap%(VoxelState.level%)"),
+      "staged battles retain the selected actor-shadow profile")
+check(source:find("local battleShadows = ShadowSettings.enabled%(%)"),
+      "staged battles retain the selected shadow setting")
+check(not source:find("battleActorShadowMode"),
+      "no forced actor-shadow override remains")
+check(not source:find("battleShadowsEnabled"),
+      "no forced global shadow override remains")
+
+print("battle_shadow_alignment_test: ok")

--- a/tests/battle_wide_hud_test.lua
+++ b/tests/battle_wide_hud_test.lua
@@ -1,0 +1,68 @@
+-- Regression coverage for the WIDE staged-battle HUD seam.
+local function check(condition, message)
+  if not condition then error(message, 2) end
+end
+
+local graphics = { rectangles = 0 }
+graphics.setColor = function() end
+graphics.rectangle = function()
+  graphics.rectangles = graphics.rectangles + 1
+end
+_G.love = { graphics = graphics }
+
+local setting = {
+  get = function() return false end,
+  setIndex = function() end,
+  setValue = function() end,
+}
+local V = {
+  require = function(name)
+    if name == "ModSetting" then return { new = function() return setting end } end
+    if name == "BattleScene" then
+      return {
+        GB_W = 160,
+        layoutMetrics = function()
+          return {
+            surfaceW = 304,
+            hud = {
+              enemy = { 0, 0, 128, 32 },
+              player = { 184, 56, 120, 40 },
+            },
+          }
+        end,
+      }
+    end
+    if name == "Voxel3D" then return { available = function() return false end } end
+    return {}
+  end,
+}
+
+local OverworldBattle = assert(loadfile("lib/OverworldBattle.lua"))(V)
+local battle = {
+  dramaticShapeShot = {
+    layout = {
+      surfaceW = 304,
+      hud = {
+        enemy = { 0, 0, 128, 32 },
+        player = { 184, 56, 120, 40 },
+      },
+    },
+  },
+  introSlide = 0,
+  statusHUDVisible = function() return true end,
+  enemy = { fainted = false },
+  player = {},
+  showEnemyTrainer = false,
+  enemySendingOut = false,
+  showPlayerBack = false,
+  safari = false,
+  demo = false,
+  introBalls = false,
+  growInScale = function() return nil end,
+}
+
+OverworldBattle.drawHudPanels(battle)
+check(graphics.rectangles == 0,
+      "WIDE staged battles do not draw leftover translucent HUD panels")
+
+print("battle_wide_hud_test: ok")


### PR DESCRIPTION
## v1.8.4 battle UI fixes\n\n- Preserve the selected OG/WIDE BATTLE LAYOUT during staged battles.\n- Align battle rendering, capture, camera, HUD, and coordinates for FIXED/FILL, offset positions, and DPI.\n- Remove WIDE-mode frosted HUD remnants and isolated battle-sprite pixel dashes.\n\nVerification: battle layout, WIDE HUD, detached-pixel, and shadow regression tests pass; changed Lua files compile with LuaJIT.