### PR TITLE
fix: a one-row top band silently drops three maps from the cache

### DIFF
--- a/data/voxel_heights.lua
+++ b/data/voxel_heights.lua
@@ -4269,7 +4269,7 @@ local profile = {
         tray = { top = { 4, 11 }, front = { 12, 15 }, x = { 2, 11 },
                  inner = { 3, 9 }, floor = 0 },
         parts = {
-          { kind = "upright", x = { 11, 14 }, top = { 0 },
+          { kind = "upright", x = { 11, 14 }, top = { 0, 0 },
             facade = { 0, 11 }, z = 0, depth = 14 },       -- the open lid
         },
       },
@@ -4611,7 +4611,7 @@ local profile = {
           -- keyboard's top-right corner and the computer's left corner.
           -- Raised to the keyboard's own height so it reads as a cable
           -- spanning them rather than a scuff on the desk
-          { kind = "upright", x = { 16, 19 }, top = { 8 },
+          { kind = "upright", x = { 16, 19 }, top = { 8, 8 },
             facade = { 8, 9 }, z = 8, depth = 2 },
           -- the computer: drawn in 2:1 ISOMETRIC, turned 45 degrees to
           -- the map -- see the `iso` branch in buildParts.  `plan` = rx

--- a/lib/Buildings.lua
+++ b/lib/Buildings.lua
@@ -605,7 +605,12 @@ local function deskSetModel(sp, pr, t)
           end
         end
       else
-        local tr0, tr1 = p.top[1], p.top[2]
+        -- A single-row top band is naturally authored as `top = { n }`.
+        -- Without this, top[2] is nil and the math.min below throws
+        -- "bad argument #2 to 'min'", which fails the whole map's mesh
+        -- job -- and a job failure is tolerated, so the map is silently
+        -- absent from the finished cache.
+        local tr0, tr1 = p.top[1], p.top[2] or p.top[1]
         local fr0, fr1 = p.facade[1], p.facade[2]
         local pd = p.depth
         -- `rise` lifts a part off the desk's top plane and `z` names its


### PR DESCRIPTION
`deskSetModel` reads a part's top band as

```lua
local tr0, tr1 = p.top[1], p.top[2]
```

Two parts in `data/voxel_heights.lua` author a single-row band as `top = { n }`, so `tr1` is nil and the `math.min` below throws:

```
Buildings.lua:647: bad argument #2 to 'min' (number expected, got nil)
```

That fails the map's whole mesh job:

| part | authored | map(s) it kills |
|---|---|---|
| `bike_shop_toolbox` "the open lid" | `top = { 0 }` | `BIKE_SHOP` |
| the desk "cord" | `top = { 8 }` | `BILLS_HOUSE`, `SILPH_CO_11F` |

The desk template's own comment names where it lands — *"BILLS_HOUSE cell 1,4 and SILPH_CO_11F cell 10,12, both found by the scan and nothing else"* — which is exactly the set that fails.

This completes both bands, and treats a missing second row as the same row so the shorthand can't fail a job again.

### Why this costs more than three maps

A failed job is tolerated: the prebuilder allows `math.max(4, state.total / 10)` failures — **44** of them at 444 jobs. So the build reports **READY**, writes a manifest short of `state.total`, and every later load rejects the *entire* cache on the first missing job.

From the player's side that is a cache which simply never loads, with no error visible anywhere unless the opt-in debugger happens to be on. It took a wiped-and-rebuilt cache plus a debugger session to find six failed jobs out of 444.

That tolerance behaviour is untouched here — it felt like a separate discussion, and I'm happy to raise it separately if you'd like a build that skipped jobs to not report READY.

### Measured

Clean build, cache directory wiped between runs (macOS, engine 0.2.24, PotatoVoxel 1.9.1, `GEOMETRY_VERSION` 28):

| | maps built | manifest records | failed jobs |
|---|---|---|---|
| before | 218 / 222 | 435 / 444 | 6 |
| after | **222 / 222** | **444 / 444** | **0** |

The same save builds all 222 maps on 1.8.4, so this arrived with the 1.9.x geometry work rather than being long-standing. The resulting v28 cache loads correctly on an Anbernic RG35XXSP (Allwinner H700, Mali-G31, 1 GB RAM, muOS).
