### PR TITLE
fix(tests): `%n` in the forward-local scan matches a literal n, not a newline

### DIFF
--- a/tests/potato_voxel_test.lua
+++ b/tests/potato_voxel_test.lua
@@ -1781,7 +1781,7 @@ end
             for j = hdr, pi do
               if lines[j]:match("^%s*for%s") and
                  (lines[j]:match("for%s+[^=]-%f[%w_]" .. name
-                                  .. "%f[^%w_][^%n=]-in")
+                                  .. "%f[^%w_][^=]-in")
                   or lines[j]:match("for%s+[%w_%s,]*%f[%w_]" .. name
                                     .. "%f[^%w_]%s*=")) then
                 return true


### PR DESCRIPTION
This is the CI failure currently on `main`:

```
FWD-LOCAL lib/WorkbenchJson.lua:27 touches `key` before its first local at 65
FAIL no module touches a name before its first local declaration (got 1, want 0)
379/380 checks passed, 1 FAILURES  (potato_voxel)
```

It's a false positive in the scanner, not a problem in `WorkbenchJson.lua`.

### Cause

`scoped()` recognises a generic-`for` as a declaration site with:

```lua
lines[j]:match("for%s+[^=]-%f[%w_]" .. name .. "%f[^%w_][^%n=]-in")
```

`%n` is **not** a newline in a Lua pattern — Lua has no such class, and an unknown alphanumeric escape matches that literal character. So `[^%n=]` reads as *"not an `n` and not an `=`"*, and the run between the loop variable and `in` can't cross any other variable containing an `n`:

```lua
for key, entry in pairs(value) do   -- `entry` has an n -> not matched
for key, val   in pairs(t)     do   -- no n            -> matched
```

Verified directly:

```lua
local line = "      for key, entry in pairs(value) do"
line:match("for%s+[^=]-%f[%w_]key%f[^%w_][^%n=]-in")  --> nil
line:match("for%s+[^=]-%f[%w_]key%f[^%w_][^=]-in")    --> "for key, entry in"
("n"):match("%n")                                     --> "n"
```

Patterns are matched line by line here, so excluding a newline was never needed — `[^=]` is the intended run.

### Why the report is wrong

`WorkbenchJson.lua:27` is `for key, entry in pairs(value)`, where `key` is the loop's own control variable. The `local key` at line 65 is a different variable in a different function. `WorkbenchJson.lua` arrived in 1.9.0 and happens to be the first module to write a loop that trips this, but any future loop whose variable list contains an `n` would be flagged the same way.

### Verified

Full suite against a fresh `bryanthaboi/gen1recomp` checkout with the mod mounted, exactly as `.github/workflows/ci.yml` runs it:

| | result |
|---|---|
| before | `379/380 checks passed, 1 FAILURES` |
| after | **`380/380 checks passed`** |

The cache suite is unaffected (`228/228`) either way.
