### PR TITLE
fix(gen2): the Gold/Silver/Crystal prebuild never enumerates a single map

### DIFF
--- a/gen2/main.lua
+++ b/gen2/main.lua
@@ -395,6 +395,16 @@ do
     "potatoVoxelGoldDeferHook", function(inner)
       return function(self, dt)
         inner(self, dt)
+        -- Gen 1 drives the prebuilder from main.lua's own update tick, but
+        -- main.lua hands off to this bridge and returns before installing it,
+        -- so nothing advanced the pump on Gold: PREBUILD CACHE enumerated its
+        -- jobs, reported 0/N and sat there for the rest of the session.
+        local okPrebuild, Prebuild = pcall(V.require, "CachePrebuild")
+        if okPrebuild and Prebuild then
+          local covered = false
+          pcall(Prebuild.update, covered)
+          pcall(Prebuild.pump, covered)
+        end
         if #deferredWork == 0 then return end
         local batch = deferredWork
         deferredWork = {}
@@ -461,6 +471,23 @@ do
       local game = payload and payload.game
       if not game then return end
       CachePrebuild.bootstrap(game)
+      -- The prebuilder must build maps the way the live path does:
+      -- Map.new() then attachAtlas() for the tileset, renderer data and
+      -- doorTiles. That needs the world, which only this bridge holds.
+      if type(CachePrebuild.setMapLoader) == "function" then
+        CachePrebuild.setMapLoader(function(id)
+          local world = game and game.world
+          local Map = mapModule()
+          local maps = world and world.maps
+          local tilesets = world and world.tilesets
+          local def = maps and maps[id]
+          local tileset = def and tilesets and tilesets[def.tileset]
+          if not (Map and def and tileset) then return nil end
+          local map = attachAtlas(world, Map.new(def, tileset))
+          if not map then return nil end
+          return map
+        end)
+      end
       local Pipelines = require("src.render.Pipelines")
       local opts = (game.save and game.save.options) or game.options
       local stored = opts and opts.pipelines and opts.pipelines.voxel

--- a/lib/CacheIdentity.lua
+++ b/lib/CacheIdentity.lua
@@ -46,7 +46,8 @@ function CacheIdentity.new(ctx)
     local hash = 17
     hash = hashString(hash, data and data.profileRevision)
     hash = hashString(hash, data and data.voxelProfileRevision)
-    local maps = data and data.maps or {}
+    -- see CachePrebuild.mapsOf: Gen 2 names this gen2Maps
+    local maps = (data and (data.maps or data.gen2Maps)) or {}
     for _, id in ipairs(sortedKeys(maps)) do
       local def = maps[id]
       hash = hashString(hash, id)

--- a/lib/CachePrebuild.lua
+++ b/lib/CachePrebuild.lua
@@ -103,6 +103,14 @@ local function masksFor(maps, id)
   return out
 end
 
+-- Gen 2 carries its map table on game.data under a generation-scoped key
+-- (src/core/Game2.lua: self.data.gen2Maps) -- the same rename the engine
+-- applies in src/mods/Gen2Compat.lua's DATA_RENAMES (maps -> gen2Maps).
+-- Reading only `maps` enumerates nothing on Gold/Silver/Crystal.
+local function mapsOf(data)
+  return data and (data.maps or data.gen2Maps)
+end
+
 Prebuild.enumerate = function(maps)
   local ids = sortedIds(maps)
   local jobs = {}
@@ -130,6 +138,36 @@ function Prebuild.pendingJobs(jobs, completed)
   return pending
 end
 
+-- A generation bridge may supply its own map loader. src.world.MapLoader
+-- builds GEN 1 maps only (it reads data.maps/data.tilesets and attaches a Gen 1
+-- TileRenderer), and a Gold map additionally needs the bridge's voxelMap proxy
+-- (Gold's cellTile answers a COLL_* byte, not a Gen 1 tile id) and its
+-- attachAtlas (tileset, renderer image/data, doorTiles). Only the bridge holds
+-- the world handle those need, so it injects the loader here.
+local injectedLoader = nil
+function Prebuild.setMapLoader(fn)
+  injectedLoader = (type(fn) == "function") and fn or nil
+end
+
+local function loadMapById(data, id)
+  if injectedLoader then
+    local ok, map = pcall(injectedLoader, id)
+    return (ok and map) or nil
+  end
+  return require("src.world.MapLoader").load(data, id)
+end
+
+-- verifyJob needs the map a just-finished job meshed. Gen 1 reaches it through
+-- MapLoader.cached; an injected loader answers from its own cache.
+local function cachedMapById(id)
+  if injectedLoader then
+    local ok, map = pcall(injectedLoader, id)
+    return (ok and map) or nil
+  end
+  local okLoader, MapLoader = pcall(require, "src.world.MapLoader")
+  return (okLoader and MapLoader and MapLoader.cached(id)) or nil
+end
+
 function Prebuild.available()
   return MeshCache.available()
 end
@@ -139,7 +177,7 @@ function Prebuild.bootstrap(game)
   pumpPause = 0
   local data = game and game.data
   MeshCache.configure(data)
-  local jobs = Prebuild.enumerate(data and data.maps)
+  local jobs = Prebuild.enumerate(mapsOf(data))
   local ready, done = MeshCache.ready(jobs)
   -- Not READY is no longer "start from zero": a build interrupted
   -- mid-session (F3) left complete atomic payloads behind, and a rescan
@@ -340,7 +378,7 @@ function Prebuild.start(game)
   -- clears them.
   local sessionDeclined, sessionGateRan = state.declined, state.gateRan
   local data = game and game.data
-  local jobs = Prebuild.enumerate(data and data.maps)
+  local jobs = Prebuild.enumerate(mapsOf(data))
   if #jobs == 0 or not MeshCache.available() then return false end
   MeshCache.begin()
   -- RESUME (F3): jobs the boot scan found complete are skipped, so a
@@ -419,7 +457,7 @@ end
 function Prebuild.wipe(game)
   if state.running then return false end
   local data = game and game.data
-  local jobs = Prebuild.enumerate(data and data.maps)
+  local jobs = Prebuild.enumerate(mapsOf(data))
   local ok = MeshCache.wipe(jobs)
   if ok then
     ChunkMesher.invalidate()
@@ -457,7 +495,7 @@ function Prebuild.refresh(game)
   state.gateRan = true
   if state.running then return end
   local data = game and game.data
-  local jobs = Prebuild.enumerate(data and data.maps)
+  local jobs = Prebuild.enumerate(mapsOf(data))
   if #jobs ~= state.total then
     -- the dataset changed under us (hot reload): full re-bootstrap
     return Prebuild.bootstrap(game)
@@ -652,10 +690,9 @@ local function startCpuTask()
     phase = "load",
   }
   task.co = coroutine.create(function()
-    local MapLoader = require("src.world.MapLoader")
     local data = state.game and state.game.data
     local started = now()
-    task.map = MapLoader.load(data, job.id)
+    task.map = loadMapById(data, job.id)
     local loadedAt = now()
     if started and loadedAt then
       local loadMs = (loadedAt - started) * 1000
@@ -889,11 +926,10 @@ local function dispatchThreaded(covered)
      and not state.completed[tostring(job.id) .. "/ring"] then
     pair = nextJob
   end
-  local MapLoader = require("src.world.MapLoader")
   local data = state.game and state.game.data
   local t0 = love and love.timer and love.timer.getTime
             and love.timer.getTime() or 0
-  local map = MapLoader.load(data, job.id)
+  local map = loadMapById(data, job.id)
   local loadMs = (love and love.timer and love.timer.getTime
                  and (love.timer.getTime() - t0) * 1000) or 0
   metrics.mainThreadMapLoadMs = metrics.mainThreadMapLoadMs + loadMs
@@ -1106,12 +1142,11 @@ function Prebuild.update(covered)
     -- slice overshoot instead of freezing the frame unaccounted, and the
     -- completed job is still reachable through MapLoader.cached for the
     -- verification below.
-    local MapLoader = require("src.world.MapLoader")
     local data = state.game and state.game.data
     state.slot = true
     ChunkMesher.requestMapId(job.id, job.slot, job.masks,
                              false, true, function()
-      return MapLoader.load(data, job.id)
+      return loadMapById(data, job.id)
     end)
   end
   -- Prebuild runs alongside normal gameplay; the covered flag (menus,
@@ -1131,8 +1166,7 @@ function Prebuild.update(covered)
   end
   local jobStatus = ChunkMesher.jobStatus(job.id, job.slot)
   if jobStatus == "pending" then return end
-  local okLoader, MapLoader = pcall(require, "src.world.MapLoader")
-  local slotMap = okLoader and MapLoader and MapLoader.cached(job.id)
+  local slotMap = cachedMapById(job.id)
   if jobStatus ~= "complete" or not slotMap
      or not MeshCache.verifyJob(slotMap, job.slot) then
     -- A single bad job must not abort the whole build: record it, release


### PR DESCRIPTION
PREBUILD CACHE reports `0/N` forever on a Gen 2 game. Three separate gaps, each of which alone is enough to stall it.

### 1. Enumeration reads a field Gen 2 never populates

`Prebuild.enumerate(data and data.maps)` at all four call sites. Gen 2 keeps its maps in `data.gen2Maps`, so enumeration saw an empty table and produced no jobs. `CacheIdentity` read the same field, so the identity's map count was 0 too.

`mapsOf(data)` prefers `data.maps` and falls back to `data.gen2Maps`, so Gen 1 behaviour is unchanged.

### 2. Nothing advanced the pump on the Gen 2 path

Gen 1 ticks the pump from its own update hook. Gold has no equivalent, so even a correctly enumerated job list sat untouched for the rest of the session. The tick is added inside the existing `RuntimeHooks.wrapOnce(..., "update", ...)` in `gen2/main.lua`.

### 3. The prebuilder's map loader is Gen 1 only

The prebuilder loads through `src.world.MapLoader`, which Gen 2 does not use. Gen 2 maps have to be built the way the live path builds them — `Map.new(def, tileset)` then `attachAtlas` — and that needs the world, which only the Gen 2 bridge holds. Hence `Prebuild.setMapLoader`, injected from `gen2/main.lua`. The hook is nil on Gen 1 and the `MapLoader` path is untouched.

## Verified

Gold, on this branch's base (`be6e6d4`), at `GEOMETRY_VERSION 55`, cold build from an empty cache:

```
736 manifest records (368 maps x 2)
3680 mesh + 3680 meta payloads
734 loader calls, 0 errors, 0 nils, 0 fallbacks
identity PVMC2|55|gold|b|1100551563|trees, matching buildinfo
restart loads the cache instead of rebuilding
```

Full suite green: cache 228/228, full 398/398, sandbox API scan clean, loading-cover ok, modkit lint/validate ok, shadow golden 66 passed / 0 failed.

## One thing worth surfacing separately

`loadMapById` discards the `pcall` error:

```lua
local ok, map = pcall(injectedLoader, id)
return (ok and map) or nil
```

A loader that raises therefore presents as a silent `0/N` stall rather than an error. That cost most of a debugging session here: an earlier version of this patch called a function that 1.9.3 had removed, and the symptom was indistinguishable from "nothing is enumerating". Worth surfacing whatever shape the Gen 2 loader ends up taking.

## Note on overlap

If you already have Gen 2 prebuild work in progress locally, treat this as a reference rather than a merge candidate — the three gaps above are what I measured, and the numbers are reproducible on a clean checkout.