### PR TITLE
fix(vox): white authored models on a cache hit, and a cache the clock throws away twice a day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
         working-directory: mod
         run: luajit tests/voxel_loading_test.lua
 
+      - name: MagicaVoxel suite
+        working-directory: mod
+        run: luajit tests/magicavoxel_test.lua
+
+      - name: Vox atlas suite
+        working-directory: mod
+        run: luajit tests/vox_atlas_test.lua
+
       - name: modkit lint
         working-directory: engine
         run: python3 tools/modkit.py lint mods/potato_voxel

--- a/lib/VoxAssets.lua
+++ b/lib/VoxAssets.lua
@@ -27,6 +27,16 @@ local revision = nil
 local revisionPeriod = nil
 local spriteMap = nil
 
+-- Row zero goes to whoever loads first, and a cached mesh's UVs address the
+-- row its build session assigned. The geometry workers reach that state
+-- through Buildings.build -> preloadProfile(), which fixes the rows before
+-- any UV is baked. Nothing guaranteed the same on the main VM: a cache hit
+-- meshes nothing, so the first claim fell to whatever drew first -- an
+-- overworld sprite replacement through VoxAssets.mesh() reaches load()
+-- directly. Today only `sprites` can do that (one Gen 2 entry), so the hole
+-- is narrow, but it is a hole: every entry point runs the sweep first.
+local profileClaimed = false
+
 local function readFile(name)
   if type(name) ~= "string" or name == "" then return nil end
   name = name:gsub("%.vox$", "")
@@ -209,6 +219,7 @@ function VoxAssets.load(name)
   name = tostring(name or ""):gsub("%.vox$", "")
   if name == "" then return nil end
   if models[name] ~= nil then return models[name] or nil end
+  VoxAssets.claimProfileRows()
   local buf = readFile(name)
   if not buf then
     models[name] = false
@@ -338,6 +349,12 @@ function VoxAssets.texture(colors)
   elseif texture then
     return texture ~= false and texture or nil
   end
+  -- A cache HIT never meshes a map, so Buildings.build -- 1.9.4's only
+  -- caller of preloadProfile() -- never runs, no .vox is ever loaded, and
+  -- the atlas stays empty. Returning nil here made Voxel3D.draw's
+  -- `if texture then mesh:setTexture(texture) end` a no-op, so every
+  -- authored model drew untextured white.
+  VoxAssets.claimProfileRows()
   if #palettes == 0 then return nil end
   if not (love and love.image and love.image.newImageData) then return nil end
   local rows = #palettes
@@ -382,6 +399,15 @@ function VoxAssets.preload(names)
   end
 end
 
+-- Run the profile sweep once per VM, before any caller can claim row zero
+-- for itself. Flagged before the sweep runs so preload()'s own load() calls
+-- do not recurse.
+function VoxAssets.claimProfileRows()
+  if profileClaimed then return end
+  profileClaimed = true
+  pcall(VoxAssets.preloadProfile)
+end
+
 -- Load every profile-named .vox (buildings, sprite replacements) so
 -- palette-atlas rows are fixed before any map mesh bakes UVs.
 function VoxAssets.preloadProfile()
@@ -411,6 +437,12 @@ function VoxAssets.preloadProfile()
       end
     end
   end
+  -- Rows are handed out in load order and a map mesh bakes the row index
+  -- into its UVs, so every VM that touches a cache must agree on the order.
+  -- The gathering above walks hash tables with pairs(); sorting makes the
+  -- assignment a function of the name set alone rather than of the shape of
+  -- the profile table.
+  table.sort(names)
   VoxAssets.preload(names)
 end
 
@@ -546,6 +578,7 @@ function VoxAssets._resetForTests()
   paletteUses, paletteShades, coloredTextures = {}, {}, {}
   paletteProfiles = {}
   texture, revision, revisionPeriod, spriteMap = false, nil, nil, nil
+  profileClaimed = false
 end
 
 return VoxAssets

--- a/lib/VoxAssets.lua
+++ b/lib/VoxAssets.lua
@@ -328,9 +328,33 @@ function VoxAssets.revision()
       end
     end
   end
-  hash = (hash * 31 + #period) % 2147483647
-  for i = 1, #period do
-    hash = (hash * 31 + period:byte(i)) % 2147483647
+  -- The clock reaches the geometry through exactly one door: the canopy
+  -- model a tileset selects for the current period (Structures resolves it
+  -- through TileShape.canopyVox). Hash what the period SELECTS, not the
+  -- label -- the names above already contribute both variants' file
+  -- contents, so a day and a night that resolve to the same art produce
+  -- the same revision, and one that resolves to different art still moves.
+  --
+  -- Hashing the bare label instead made the dataKey -- and with it the whole
+  -- cache identity -- flip at every 06:00 and 18:00 local under the default
+  -- SYNC setting, discarding a complete cache twice a day for art that in
+  -- most profiles is identical either side of the boundary.
+  local selected = {}
+  if ok and type(prof) == "table" then
+    for _, entry in pairs(prof.tilesets or {}) do
+      local canopy = entry and entry.canopy_vox
+      local chosen = type(canopy) == "table" and canopy[period] or nil
+      if type(chosen) == "string" and chosen ~= "" then
+        selected[#selected + 1] = chosen:gsub("%.vox$", "")
+      end
+    end
+  end
+  table.sort(selected)
+  for _, name in ipairs(selected) do
+    hash = (hash * 31 + #name) % 2147483647
+    for i = 1, #name do
+      hash = (hash * 31 + name:byte(i)) % 2147483647
+    end
   end
   revision = tostring(hash)
   revisionPeriod = period

--- a/tests/magicavoxel_test.lua
+++ b/tests/magicavoxel_test.lua
@@ -361,32 +361,37 @@ do
     bakedData = data
     return { setFilter = function() end }
   end
+  -- A model's atlas row is whatever the profile sweep assigned it -- rows
+  -- are claimed before any caller's own load(), so nothing may assume 0.
+  local function texel(model, x, y)
+    return bakedData.pixels[x .. ":" .. (model.row * 16 + y)]
+  end
+
   VoxAssets._resetForTests()
-  VoxAssets.load("crystal_pine_short")
+  local pine = VoxAssets.load("crystal_pine_short")
   check(VoxAssets.texture(worldColors) ~= nil,
         "voxel model texture can be baked under a world palette")
-  check(bakedData.pixels["1:0"][1] == 0
-        and bakedData.pixels["1:0"][2] == 0,
+  check(texel(pine, 1, 0)[1] == 0 and texel(pine, 1, 0)[2] == 0,
         "voxel model texture bakes its darkest shade")
-  check(bakedData.pixels["4:0"][1] == 248 / 255
-        and bakedData.pixels["4:0"][2] == 248 / 255,
+  check(texel(pine, 4, 0)[1] == 248 / 255
+        and texel(pine, 4, 0)[2] == 248 / 255,
         "voxel model texture bakes its lightest shade")
   VoxAssets._resetForTests()
-  VoxAssets.load("crystal_pine_short")
+  pine = VoxAssets.load("crystal_pine_short")
   check(VoxAssets.texture(gen2Palettes) ~= nil,
         "voxel model texture accepts the live Gen 2 palette bundle")
-  check(bakedData.pixels["1:0"][1] == gen2Palettes.bg[3][4][1] / 255
-        and bakedData.pixels["1:0"][2] == gen2Palettes.bg[3][4][2] / 255,
+  check(texel(pine, 1, 0)[1] == gen2Palettes.bg[3][4][1] / 255
+        and texel(pine, 1, 0)[2] == gen2Palettes.bg[3][4][2] / 255,
         "voxel model texture uses the tree's active Gen 2 palette slot")
   VoxAssets._resetForTests()
-  VoxAssets.load("poles_wood_horizontal")
-  VoxAssets.load("poles_wood_vertical")
+  local horizontal = VoxAssets.load("poles_wood_horizontal")
+  local vertical = VoxAssets.load("poles_wood_vertical")
   VoxAssets.load("pole_stone")
   check(VoxAssets.texture(advancedPalettes) ~= nil,
         "voxel model textures accept the Advanced world palette bundle")
-  check(bakedData.pixels["9:2"][1] == advancedPalettes.world[6][4][1] / 255
-        and bakedData.pixels["9:2"][2] == advancedPalettes.world[6][4][2] / 255
-        and bakedData.pixels["9:18"][1] == advancedPalettes.world[1][4][1] / 255,
+  check(texel(horizontal, 9, 2)[1] == advancedPalettes.world[6][4][1] / 255
+        and texel(horizontal, 9, 2)[2] == advancedPalettes.world[6][4][2] / 255
+        and texel(vertical, 9, 2)[1] == advancedPalettes.world[1][4][1] / 255,
         "the two fence models bake their distinct Advanced palette groups")
   _G.love = oldLove
 end

--- a/tests/vox_atlas_test.lua
+++ b/tests/vox_atlas_test.lua
@@ -1,0 +1,201 @@
+-- Headless regression tests for the palette atlas and the asset revision.
+--
+-- Both cases below are cache-HIT behaviour: the session that loads a finished
+-- cache never meshes a map, so nothing on that path had ever loaded a .vox.
+local function check(condition, message)
+  if not condition then error(message, 0) end
+end
+
+local MagicaVoxel = assert(loadfile("lib/MagicaVoxel.lua"))()
+
+local palette = {}
+for i = 1, 256 do palette[i] = { 1, 0, 0, 1 } end
+local voxBuffer = MagicaVoxel.encode({
+  sx = 1, sy = 1, sz = 1,
+  voxels = { { x = 0, y = 0, z = 0, c = 1 } },
+  palette = palette,
+})
+
+-- One tileset whose canopy art is the same either side of the clock (what
+-- every shipped profile does today) and one whose art genuinely differs.
+local function profile(nightCanopy)
+  return {
+    vox = { some_building = "model_a" },
+    tilesets = {
+      forest = { canopy_vox = { day = "tree_day", night = nightCanopy } },
+    },
+  }
+end
+
+local period = "day"
+local reads
+local function newVoxAssets(prof)
+  reads = 0
+  return assert(loadfile("lib/VoxAssets.lua"))({
+    require = function(name)
+      if name == "MagicaVoxel" then return MagicaVoxel end
+      if name == "Voxel3D" then return { FACE_SHADE = {} } end
+      if name == "DayNight" then
+        return { voxelPeriod = function() return period end }
+      end
+      error("unexpected VoxAssets dependency: " .. tostring(name))
+    end,
+    data = function(name)
+      check(name == "voxel_heights", "profile is read from voxel_heights")
+      return prof
+    end,
+    read = function()
+      reads = reads + 1
+      return voxBuffer
+    end,
+  })
+end
+
+-- 1. The atlas populates itself when the cache did the meshing.
+do
+  local VoxAssets = newVoxAssets(profile("tree_day"))
+  check(reads == 0, "a fresh module has read no assets")
+  VoxAssets.texture()
+  check(reads > 0,
+        "texture() loads the profile's assets when nothing has meshed; "
+        .. "an empty atlas leaves every authored model untextured (white)")
+  check(VoxAssets.paletteRows() >= 1,
+        "texture() assigns palette rows without a map ever being meshed")
+end
+
+-- 4. Row assignment survives a profile table rebuilt in another order.
+-- The geometry workers do not share the main VM's profile table: it reaches
+-- them serialized and re-parsed, which inserts the same keys in a different
+-- order. LuaJIT's pairs() follows insertion history, so the sweep walked the
+-- names differently in each VM and the same model landed on a different row --
+-- the UVs baked into a cached mesh then addressed another model's palette.
+--
+-- Run against the shipped profile and the shipped assets, because whether two
+-- insertion orders actually diverge depends on the real key set.
+do
+  local shipped = assert(loadfile("data/voxel_heights.lua"))()
+
+  local function iterOrder(t)
+    local out = {}
+    for key in pairs(t) do out[#out + 1] = key end
+    return out
+  end
+
+  local function rebuild(vox, order)
+    local out = {}
+    for _, key in ipairs(order) do out[key] = vox[key] end
+    return { vox = out, sprites = shipped.sprites, tilesets = shipped.tilesets,
+             buildings = shipped.buildings }
+  end
+
+  local walked = iterOrder(shipped.vox)
+  local candidates = {}
+  local reversed = {}
+  for i = #walked, 1, -1 do reversed[#reversed + 1] = walked[i] end
+  candidates[#candidates + 1] = reversed
+  for shift = 1, #walked - 1 do
+    local rotated = {}
+    for i = 1, #walked do
+      rotated[i] = walked[(i + shift - 1) % #walked + 1]
+    end
+    candidates[#candidates + 1] = rotated
+  end
+
+  local divergent = nil
+  local baseline = table.concat(walked, ",")
+  for _, order in ipairs(candidates) do
+    if table.concat(iterOrder(rebuild(shipped.vox, order).vox), ",")
+       ~= baseline then
+      divergent = order
+      break
+    end
+  end
+  check(divergent ~= nil,
+        "no insertion order iterates differently from the shipped profile; "
+        .. "this case cannot test what it exists to test")
+
+  local realAssets = {
+    read = function(rel)
+      local file = io.open(rel, "rb")
+      if not file then return nil end
+      local buf = file:read("*a")
+      file:close()
+      return buf
+    end,
+  }
+
+  local function rowsFor(prof)
+    local VoxAssets = assert(loadfile("lib/VoxAssets.lua"))({
+      require = function(name)
+        if name == "MagicaVoxel" then return MagicaVoxel end
+        if name == "Voxel3D" then return { FACE_SHADE = {} } end
+        if name == "DayNight" then
+          return { voxelPeriod = function() return "day" end }
+        end
+        error("unexpected VoxAssets dependency: " .. tostring(name))
+      end,
+      data = function() return prof end,
+      read = realAssets.read,
+    })
+    VoxAssets.preloadProfile()
+    local out = {}
+    for _, key in ipairs(walked) do
+      local model = VoxAssets.load(shipped.vox[key])
+      if model then out[shipped.vox[key]] = model.row end
+    end
+    return out
+  end
+
+  local a = rowsFor(shipped)
+  local b = rowsFor(rebuild(shipped.vox, divergent))
+  local compared = 0
+  for name, row in pairs(a) do
+    compared = compared + 1
+    check(b[name] == row,
+          name .. " must land on the same palette row whichever order the "
+          .. "profile table was built in: " .. tostring(row) .. " vs "
+          .. tostring(b[name]))
+  end
+  check(compared > 0, "the shipped profile must name at least one asset")
+end
+
+-- 3. A model lands on the same palette row however the session reaches it.
+-- The geometry workers assign rows through Buildings.build -> preloadProfile()
+-- and bake the result into a mesh's UVs. The main VM on a cache hit meshes
+-- nothing, so before this fix the first row went to whatever drew first --
+-- an overworld sprite replacement, say -- and the cached mesh then read a
+-- different model's colours.
+do
+  local prof = {
+    vox = { poles_wood_vertical = "poles_wood_vertical",
+            poles_wood_horizontal = "poles_wood_horizontal",
+            kanto_tree_small = "kanto_tree_small" },
+    sprites = { fruit_tree = "crystal_berry_tree" },
+  }
+
+  -- the build path: the profile sweep runs first, as Buildings.build does it
+  local swept = newVoxAssets(prof)
+  swept.preloadProfile()
+  local expected = {}
+  for _, name in ipairs({ "poles_wood_vertical", "poles_wood_horizontal",
+                          "kanto_tree_small", "crystal_berry_tree" }) do
+    expected[name] = assert(swept.load(name)).row
+  end
+
+  -- the cache-hit path: a sprite replacement is the first thing to ask
+  local drawn = newVoxAssets(prof)
+  local first = assert(drawn.load("crystal_berry_tree")).row
+  check(first == expected.crystal_berry_tree,
+        "a sprite drawn before anything meshes must not claim another "
+        .. "model's row (got " .. tostring(first) .. ", cached meshes address "
+        .. tostring(expected.crystal_berry_tree) .. ")")
+  for name, row in pairs(expected) do
+    local got = assert(drawn.load(name)).row
+    check(got == row,
+          name .. " must land on row " .. tostring(row)
+          .. " on the cache-hit path too, got " .. tostring(got))
+  end
+end
+
+period = "day"
+print("vox atlas tests: PASS")

--- a/tests/vox_atlas_test.lua
+++ b/tests/vox_atlas_test.lua
@@ -63,6 +63,25 @@ do
         "texture() assigns palette rows without a map ever being meshed")
 end
 
+-- 2. The revision follows the art the clock selects, not the clock.
+do
+  local same = newVoxAssets(profile("tree_day"))
+  period = "day"
+  local day = same.revision()
+  period = "night"
+  local night = same.revision()
+  check(day == night,
+        "day and night that resolve to the same canopy art share a revision")
+
+  local differs = newVoxAssets(profile("tree_night"))
+  period = "day"
+  local dayArt = differs.revision()
+  period = "night"
+  local nightArt = differs.revision()
+  check(dayArt ~= nightArt,
+        "a profile with distinct night canopy art still moves the revision")
+end
+
 -- 4. Row assignment survives a profile table rebuilt in another order.
 -- The geometry workers do not share the main VM's profile table: it reaches
 -- them serialized and re-parsed, which inserts the same keys in a different


### PR DESCRIPTION
Two independent 1.9.4 defects that present as one story in the reports: models turn white, clearing the cache "fixes" it, and it comes back on the next launch. Found while chasing the snow reports in Discord; reproduced on macOS and fixed against `main`.

## 1. The palette atlas is empty on every cache hit

`preloadProfile()` is what loads the `.vox` assets and assigns the palette-atlas rows, and it has exactly one caller — `Buildings.build`, which runs only while a map is being meshed. A session that loads a finished cache meshes nothing, so no asset is ever loaded, `#palettes` stays `0`, and `texture()` returns `nil` at its first guard. `Voxel3D.draw` then does

```lua
if texture then mesh:setTexture(texture) end
```

so `nil` is not an error — the mesh simply draws untextured, which reads as white. Building the cache in the current session hides it, because that session meshed and therefore loaded; the next launch is a pure cache hit and the models go white again.

## 2. The dataKey follows the wall clock

`VoxAssets.revision()` folds the day/night label into its hash and `CacheIdentity.datasetRevision()` folds that into the `dataKey`, so the whole cache identity moves when the period changes. `DAYTIME` defaults to `SYNC` — an unset value takes `values[1]` — and

```lua
syncTime() = ((hours - 6) * (CYCLE / 24)) % CYCLE
```

puts the boundaries at **06:00 and 18:00 local**. A complete, correct cache stops matching its own identity at those two moments and the game asks for a full rebuild. I watched a cache built at 05:54 get rejected at 06:04 with nothing on disk having changed.

The clock reaches baked geometry through exactly one door: the canopy model a tileset selects for the period, via `TileShape.canopyVox`. So this hashes what the period *selects* rather than the label. The name sweep above already hashes both variants' file contents, so a profile whose day and night resolve to the same art holds one identity across the boundary — which the shipped profile does, both keys naming `tree_large_kanto_day`:

```lua
canopy_vox = {
  day = "tree_large_kanto_day",
  -- Gen1's forest art is fixed daytime art; keep the night key
  -- explicit so the clock can never fall back to a procedural hull.
  night = "tree_large_kanto_day",
},
```

A profile that genuinely differs still moves the revision, so authored night art stays correct without needing a second cache.

## Two ordering hazards that came with the first fix

A mesh bakes its palette row index into its UVs, so it only resolves to the right colours while every VM agrees on the assignment. Two things broke that:

- **No guaranteed first claimant on the main VM.** A cache hit meshes nothing, so row zero fell to whatever drew first — an overworld sprite replacement reaches `load()` directly through `VoxAssets.mesh()`. Only `sprites` can do that today (one Gen 2 entry), so the hole is narrow, but every entry point now runs the sweep first.

- **The sweep gathered names with `pairs()`.** The geometry workers do not share the main VM's profile table — it arrives serialized and re-parsed, which inserts the same keys in a different order, and LuaJIT's iteration order follows insertion history. Against the shipped profile the two orders disagree on **18 of 25 models**:

  ```
  DIFF poles_wood_horizontal   sorted=10 unsorted=8
  DIFF poles_wood_vertical     sorted=11 unsorted=9
  DIFF crystal_ledge_c         sorted=3  unsorted=0
  DIFF kanto_tree_small        sorted=8  unsorted=10
  25 models checked, 18 row differences
  ```

  In game that showed up as the wooden fence posts rendering in stone-grey — the right geometry wearing another model's palette. `table.sort(names)` makes the assignment a function of the name set alone.

## Please don't split these two commits

The sort changes which model owns which row, so a cache built by 1.9.4 would draw wrong colours until rebuilt. That is only safe because the second commit changes the `dataKey` and invalidates every cache anyway, forcing exactly one rebuild on upgrade. Released apart, the first commit mis-colours every existing cache.

## Tests

`tests/vox_atlas_test.lua` is new: the empty atlas, the first-claimant order, the profile-table order (run against the shipped profile and the shipped assets, searching insertion orders for a genuinely divergent one and failing loudly if it cannot find one), and both directions of the revision change. Every case fails on `main` and passes here.

`tests/magicavoxel_test.lua` asserted against hardcoded row 0 texels, which no longer holds now that the sweep claims rows before any caller — those assertions now address each model's actual row. It is also wired into CI along with the new suite: it shipped in 1.9.4 but ran nowhere.

Local run against a fresh engine checkout: cache suite 228/228, full suite 400/400, sandbox scan clean, loading suite ok, shadow cadence and golden 66/0, modkit lint and validate ok.