### PR TITLE
fix: stop water shading itself dark along a map connection

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -5,6 +5,7 @@
 # private require against the archive (CONTRIBUTING-mods.md "What the PR
 # must contain", 2).
 tests/potato_voxel_test.lua
+tests/voxel_seam_ao_test.lua
 tests/potato_voxel_cache_test.lua
 tests/voxel_loading_test.lua
 tests/shadow_cadence_probe.lua

--- a/lib/GeometryBuilder.lua
+++ b/lib/GeometryBuilder.lua
@@ -55,6 +55,8 @@ function GeometryBuilder.emit(map, bodyOnly, masks, sink, waterSink)
   local waterPush = waterSink and waterSink.push or nil
   local tileset = map.tileset
   local S = Structures.forMap(map)
+  local def = map.def
+  local tw, th = def.width * 4, def.height * 4         -- map size in tiles
   local perRow = tileset.tilesPerRow or 16
   local atlasW = tileset.imageWidth or (perRow * 8)
   local atlasH = tileset.imageHeight or 48
@@ -66,6 +68,51 @@ function GeometryBuilder.emit(map, bodyOnly, masks, sink, waterSink)
     if run then return run.h end
     local s = S.shapeAt[k]
     return s and s.h or 0
+  end
+
+  -- Does the cell one step past the body belong to a CONNECTED NEIGHBOUR
+  -- rather than to the border ring?
+  --
+  -- Structures fills the whole ring with the map's border block, and
+  -- heightAt answers out of that analysis wherever it is asked -- so a
+  -- cell just outside the body always reports a neighbour standing there,
+  -- and outdoors that neighbour is the solid tree wall. Where the map ENDS
+  -- that is the truth. Where it CONNECTS it is not: the ring is not drawn
+  -- there at all (`masks` suppress it under the neighbour's body, and a
+  -- body-only build emits no ring in the first place) and the neighbour's
+  -- own ground runs flush with the seam.
+  --
+  -- Only the AO probe asks. The faces themselves still read heightAt
+  -- straight, because a face is a hole if it is wrong and a crease is only
+  -- a shade.
+  --
+  -- A cell outside the body on BOTH axes is not flush whatever connects: a
+  -- neighbour to the east is not also north of itself, and the ring really
+  -- does stand in the corner past the end of the seam.
+  local conn = def.connections
+  local cN = (conn and conn.north) ~= nil
+  local cS = (conn and conn.south) ~= nil
+  local cE = (conn and conn.east) ~= nil
+  local cW = (conn and conn.west) ~= nil
+  local anyConn = cN or cS or cE or cW
+  local function flush(tx, ty)
+    if not anyConn then return false end
+    if ty >= 0 and ty < th then
+      if tx >= tw then return cE end
+      if tx < 0 then return cW end
+    end
+    if tx >= 0 and tx < tw then
+      if ty >= th then return cS end
+      if ty < 0 then return cN end
+    end
+    return false
+  end
+
+  -- The AO probe's own neighbour test: raised enough to crowd this corner,
+  -- and actually THERE to do it.
+  local function crowds(tx, ty, h)
+    if flush(tx, ty) then return false end
+    return heightAt(tx, ty) > h
   end
 
   -- one atlas-rect UV, optionally cropped to art rows [vTop, vBot] of 8
@@ -117,14 +164,14 @@ function GeometryBuilder.emit(map, bodyOnly, masks, sink, waterSink)
   -- A top face's four corners, each occluded by the three cells that touch
   -- it: two edge neighbours and the diagonal between them.
   local function aoShades(tx, ty, h, shade)
-    local n = heightAt(tx, ty - 1) > h
-    local s = heightAt(tx, ty + 1) > h
-    local e = heightAt(tx + 1, ty) > h
-    local w = heightAt(tx - 1, ty) > h
-    local nw = heightAt(tx - 1, ty - 1) > h
-    local ne = heightAt(tx + 1, ty - 1) > h
-    local sw = heightAt(tx - 1, ty + 1) > h
-    local se = heightAt(tx + 1, ty + 1) > h
+    local n = crowds(tx, ty - 1, h)
+    local s = crowds(tx, ty + 1, h)
+    local e = crowds(tx + 1, ty, h)
+    local w = crowds(tx - 1, ty, h)
+    local nw = crowds(tx - 1, ty - 1, h)
+    local ne = crowds(tx + 1, ty - 1, h)
+    local sw = crowds(tx - 1, ty + 1, h)
+    local se = crowds(tx + 1, ty + 1, h)
     if not (n or s or e or w or nw or ne or sw or se) then return shade end
     local function corner(a, b, d)
       local k = 0
@@ -249,8 +296,6 @@ function GeometryBuilder.emit(map, bodyOnly, masks, sink, waterSink)
     push(c, uv, shade)
   end
 
-  local def = map.def
-  local tw, th = def.width * 4, def.height * 4         -- map size in tiles
   local r = bodyOnly and 0 or RING * 4
 
   -- true when the (ring) position lies under a connected neighbour's body

--- a/lib/MeshCache.lua
+++ b/lib/MeshCache.lua
@@ -151,7 +151,10 @@ end
 --     single-row upright top bands during Gen1 precache.
 -- 70: Replace Gen1 jump-ledge terminal caps when tile 52 sits over ground.
 -- 71: Give the Gen1 terminal-cap copy tile 52's Advanced palette group.
-MeshCache.GEOMETRY_VERSION = 71
+-- 72: Stop the corner AO probe shading a connected map edge against border
+--     ring the connection hides, which changes the baked vertex shade of
+--     every tile along a seam.
+MeshCache.GEOMETRY_VERSION = 72
 local Identity = CacheIdentity.new({
   geometryVersion = MeshCache.GEOMETRY_VERSION,
 })

--- a/tests/voxel_seam_ao_test.lua
+++ b/tests/voxel_seam_ao_test.lua
@@ -1,0 +1,107 @@
+-- A map CONNECTION is not a wall: the seam must not shade itself.
+--
+-- The corner AO probe in GeometryBuilder reads the cells crowding a top
+-- face out of Structures' analysis, and that analysis covers the RING as
+-- well as the body -- ring cells carrying the map's border block, which
+-- outdoors is the solid tree wall. So one tile past the body edge always
+-- reads as a raised neighbour: every edge tile counts two crowders on its
+-- outer corners and comes out at 1 - 2*AO_STEP.
+--
+-- Where the map ENDS that is right. Where it CONNECTS it is not. The ring
+-- there is not drawn at all -- GeometryBuilder.emit's `masks` suppress it
+-- under the neighbour's body, and a body-only build (which is how every
+-- neighbour is meshed) never emits a ring -- and the neighbour's own
+-- ground runs flush with the seam. Shading against a wall nobody can see
+-- lays a dark line down every connection, and both sides do it, each
+-- against its own ring, so it comes out symmetric: a tile of linear
+-- falloff either side of the seam bottoming out at 1 - 2*AO_STEP, which is
+-- 0.568.
+--
+-- On land the tile art mostly swallows it. On the one surface in the game
+-- with no art to hide behind -- open water spanning a connection -- it
+-- reads as a shadow floating on the sea.
+--
+--   luajit tests/voxel_seam_ao_test.lua      (from the game root)
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Data = require("src.core.Data")
+Data:load()
+
+local run = T.sdk.loadMod("mods/potato_voxel", { data = Data })
+T.eq(#run.errors, 0, "potato_voxel loads clean: "
+                     .. table.concat(run.errors, "; "))
+
+local lib = run.loader.exports.potato_voxel.lib
+local ChunkMesher = lib.require("ChunkMesher")
+local Structures = lib.require("Structures")
+local Shapes = lib.require("TileShape")
+
+-- Open sea, two blocks square, connected EASTWARD and walled on the other
+-- three sides -- so one fixture states both halves of the invariant. No
+-- atlas, no GPU and no fixture map: geometry() is pure arithmetic.
+local SEA_TILE = 20
+local seaMap = {
+  id = "SEAM_AO_TEST",
+  tileset = { id = "SEAM_AO_SET", image = "gfx/tilesets/seam_ao.png",
+              tilesPerRow = 16, imageWidth = 128, imageHeight = 48,
+              blocks = {}, grassTile = -1 },
+  def = { width = 2, height = 2, tileset = "SEAM_AO_SET",
+          connections = { east = { map = "SEAM_AO_TEST_EAST", offset = 0 } } },
+  walkable = {},
+  waterTiles = { [SEA_TILE] = true },
+  doorTiles = {},
+  tileAt = function() return SEA_TILE end,
+  cellTile = function() return SEA_TILE end,
+  isWaterCell = function() return true end,
+  isWalkableCell = function() return false end,
+  inBounds = function(_, cx, cy)
+    return cx >= 0 and cy >= 0 and cx < 4 and cy < 4
+  end,
+}
+
+Structures.invalidate(seaMap.id)
+local _, _, _, seaVerts = ChunkMesher.geometry(seaMap, true, nil, true)
+
+-- The body is 8 tiles square, so its west face stands at x=0 and its east
+-- face at x=64. The corners at z=0 and z=64 are the map's own north and
+-- south edges, ringed for real, and are left out: what is under test is
+-- the seam, not the corners it runs between.
+local EAST, WEST, SPAN = 64, 0, 64
+local eastLit, eastDark, westDark, worst = 0, 0, 0, 1
+for _, v in ipairs(seaVerts) do
+  local x, z, shade = v[1], v[3], v[6]
+  if z > 0 and z < SPAN then
+    if x == EAST then
+      if shade < 1 then
+        eastDark = eastDark + 1
+        worst = math.min(worst, shade)
+      else
+        eastLit = eastLit + 1
+      end
+    elseif x == WEST and shade < 1 then
+      westDark = westDark + 1
+      worst = math.min(worst, shade)
+    end
+  end
+end
+
+T.check(eastLit > 0, "the connected edge carries water corners at all")
+T.eq(eastDark, 0,
+  "no water corner on a CONNECTED edge is occlusion-shaded: the border "
+  .. "ring it would shade against is suppressed under the neighbour's "
+  .. "body, and the neighbour's own water runs flush to the seam")
+T.check(westDark > 0,
+  "while the WALLED edge still is -- the fix is the connection, not a "
+  .. "blanket amnesty for every cell that happens to sit on a map edge")
+T.check(worst > 0.56 and worst < 0.58,
+  "and the shade a real wall lays is the two-crowder step, 1 - 2*AO_STEP "
+  .. "= 0.568 -- the value measured off the seam band this fixes")
+
+Structures.invalidate(seaMap.id)
+ChunkMesher.invalidate(seaMap.id)
+Shapes.invalidate()
+
+run.release()
+T.finish("potato_voxel")


### PR DESCRIPTION
There is a dark vertical band across the water wherever a map connection runs through it, about two tiles wide. It reads as a shadow but nothing is casting it. Vermilion to Route 11 is the easiest place to see it, Cerulean has it on three sides at once.

It is the corner AO in `GeometryBuilder`, not the shadow map.

`Structures` fills the whole border ring with the map's border block, which outdoors is the solid tree wall, and `heightAt` answers out of that analysis wherever it is asked. So the cell one tile past the body edge always comes back raised. Water sits at height -2 and loses to anything, so every edge water tile counts two crowders on its outer corners and the step gets interpolated across the tile. The neighbouring map does the same to its own edge, which is why the band is symmetric with the seam down the middle.

Where a map actually ends, that is correct. Where it connects it is not. The ring is never drawn there (`masks` suppress it under the neighbour's body, and a body-only build, which is how every neighbour gets meshed, emits no ring at all) and the neighbour's ground runs flush to the seam. So it is shading against a wall nobody can see.

The probe now treats a cell past a connected edge as flush, so it crowds nothing. The faces themselves still read `heightAt` straight, because a face that is wrong leaves a hole while a crease that is wrong is only a shade. A cell outside the body on both axes still counts, since the ring does stand in the corner past the end of a seam.

This looks like it is in the same area as "Fixed trees appearing incorrectly between connected maps" from 1.9.4, but it is a separate thing: that one was about ring geometry being drawn, this one is about ring geometry being counted for shading after it is already suppressed.

If you want to check the diagnosis quickly: the darkest point of the band is a multiplier of exactly `1 - 2*AO_STEP`, which is 0.568. Sampling water either side of the seam off a phone screenshot gives 0.569.

### Geometry version

This also bumps `MeshCache.GEOMETRY_VERSION` to 72. The shading is baked into vertex colours, so without the bump a warm cache keeps serving the old mesh and the fix looks like it did nothing. I lost an evening to that before working out what was happening.

### Test

`tests/voxel_seam_ao_test.lua`. Open sea two blocks square, connected east and walled on the other three sides, so one fixture states both halves: nothing shaded on the connected edge, and the walled edge still measuring the two-crowder step. That second assertion is the one worth having, it is what stops a fix like this from just flattening all the contact shading. On main it fails with 14 shaded corners on the connected edge.

It requires an engine module, so it is in `.modkitignore` with the rest of the suite.

Worth being upfront about how far I got verifying it. The seam test passes, and I confirmed the fix on an Android device. I could not get a clean run of `tests/potato_voxel_test.lua`, it stops at the Gold Map `isOutdoor` check, and my engine checkout is old enough that it also rejects the `compute` permission outright, so I had to work around that to load the mod at all. Both of those look like my setup rather than anything here, but I have not proved that, so please run the suite before merging.

### How much of the game this touches

Scanning `data/generated/maps.lua` for connections whose body edge carries water: 26 edges, 469 tiles. They come in matched pairs, both sides of each seam with the same count, which is the same "each map shades its own edge" behaviour showing up in the map data rather than in the pixels.

```
CERULEAN_CITY   north -> ROUTE_24         36/ 80 edge tiles are water
ROUTE_14        east  -> ROUTE_13         67/108
ROUTE_20        east  -> ROUTE_19         32/ 36
ROUTE_21        south -> CINNABAR_ISLAND  32/ 40
VERMILION_CITY  east  -> ROUTE_11         30/ 72
...
```

I left CHANGELOG.md alone since it looks like you write it per release, happy to add an entry if you would rather.


<img width="1290" height="610" alt="seam-before-after" src="https://github.com/user-attachments/assets/6ec2305d-b75b-471b-b692-4d80271d7926" />
